### PR TITLE
node_modulesもバインドされてた問題を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
 version: '3'
+volumes:
+  frontend_node_modules:
+  backend_node_modules:
 services:
   postgres:
     container_name: postgres
@@ -22,6 +25,7 @@ services:
       - 5173:5173
     volumes:
       - "./frontend:/frontend"
+      - frontend_node_modules:/frontend/node_modules
 
   backend:
     container_name: backend
@@ -32,6 +36,7 @@ services:
       - "3000:3000"
     volumes:
       - "./backend:/backend"
+      - backend_node_modules:/backend/node_modules
     depends_on:
       - postgres
     healthcheck:


### PR DESCRIPTION
ローカルのファイルを全部マウントしていたのでローカルに環境がない状態だとdocker-composeが動かなかった
qiitaを参考にコンテナ用のnode_moduleはdockerVolumeに保存する様にした

https://qiita.com/suin/items/e53eee56da23d476addc