### PR TITLE
Makefileにコンテナに入るためのターゲットを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,7 @@ logs:
 	docker-compose -f docker-compose.yml logs
 
 .PHONY: all $(NAME) up down ps logs
+
+.PHONY:	frontend backend postgres
+frontend backend postgres:
+	docker-compose -f docker-compose.yml exec $@ /bin/bash


### PR DESCRIPTION
`make backend`とするとbackendコンテナに入れるてきなやつ。
あったら便利じゃない？ということで。