### PR TITLE
ソケット周りの便利関数を切り出し

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -23,7 +23,7 @@ import { OperationKickDto } from 'src/chatrooms/dto/operation-kick.dto';
 import { OperationMuteDto } from 'src/chatrooms/dto/operation-mute.dto';
 import { OperationBanDto } from 'src/chatrooms/dto/operation-ban.dto';
 import { OperationNomminateDto } from 'src/chatrooms/dto/operation-nomminate.dto';
-import { generateFullRoomName } from 'src/utils/socket/SocketRoom';
+import { generateFullRoomName, joinChannel } from 'src/utils/socket/SocketRoom';
 
 const secondInMilliseconds = 1000;
 const minuteInSeconds = 60;
@@ -60,8 +60,8 @@ export class ChatGateway implements OnGatewayConnection {
     const userId = user.id;
     // [システムチャンネルへのjoin]
     //TODO チャットに依存しない機能になりそう
-    this.joinChannel(client, 'User', userId);
-    this.joinChannel(client, 'Global', 'global');
+    joinChannel(client, 'User', userId);
+    joinChannel(client, 'Global', 'global');
 
     // [ユーザがjoinしているチャットルーム(ハードリレーション)の取得]
     const joiningRooms = (
@@ -707,17 +707,6 @@ export class ChatGateway implements OnGatewayConnection {
       socks
     );
     this.server.in(fullUserRoomName).socketsLeave(fullChatRoomName);
-  }
-
-  //TODO ゲーム側にもつかえるので切り分けたい
-  private joinChannel(
-    @ConnectedSocket() client: Socket,
-    roomType: 'ChatRoom' | 'User' | 'Global',
-    roomName: any
-  ) {
-    const fullRoomName = generateFullRoomName(roomType, roomName);
-    client.join(fullRoomName);
-    console.log(`client ${client.id} joined to ${fullRoomName}`);
   }
 
   private async sendResults(

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -60,8 +60,8 @@ export class ChatGateway implements OnGatewayConnection {
     const userId = user.id;
     // [システムチャンネルへのjoin]
     //TODO チャットに依存しない機能になりそう
-    joinChannel(client, 'User', userId);
-    joinChannel(client, 'Global', 'global');
+    joinChannel(client, generateFullRoomName('User', userId));
+    joinChannel(client, generateFullRoomName('Global', 'global'));
 
     // [ユーザがjoinしているチャットルーム(ハードリレーション)の取得]
     const joiningRooms = (

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -28,6 +28,7 @@ import {
   joinChannel,
   usersLeave,
   usersJoin,
+  sendResultRoom,
 } from 'src/utils/socket/SocketRoom';
 
 const secondInMilliseconds = 1000;
@@ -696,36 +697,32 @@ export class ChatGateway implements OnGatewayConnection {
     }
   ) {
     if (typeof target.userId === 'number') {
-      await this.sendResultRoom(op, 'User', target.userId, payload);
+      await sendResultRoom(
+        this.server,
+        op,
+        generateFullRoomName('User', target.userId),
+        payload
+      );
     }
     if (typeof target.roomId === 'number') {
-      await this.sendResultRoom(op, 'ChatRoom', target.roomId, payload);
+      await sendResultRoom(
+        this.server,
+        op,
+        generateFullRoomName('ChatRoom', target.roomId),
+        payload
+      );
     }
     if (target.global) {
-      await this.sendResultRoom(op, 'Global', target.global, payload);
+      await sendResultRoom(
+        this.server,
+        op,
+        generateFullRoomName('Global', target.global),
+        payload
+      );
     }
     if (target.client) {
       console.log('sending downlink to client:', target.client.id, op, payload);
       target.client.emit(op, payload);
     }
-  }
-
-  //TODO ゲーム側にもつかえるので切り分けたい
-  /**
-   * サーバからクライアントに向かってデータを流す
-   * @param roomType
-   * @param roomName
-   * @param payload
-   */
-  private async sendResultRoom(
-    op: string,
-    roomType: 'ChatRoom' | 'User' | 'Global',
-    roomName: any,
-    payload: any
-  ) {
-    const fullName = generateFullRoomName(roomType, roomName);
-    const socks = await this.server.to(fullName).allSockets();
-    console.log('sending downlink to:', fullName, op, payload, socks);
-    this.server.to(fullName).emit(op, payload);
   }
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -27,6 +27,7 @@ import {
   generateFullRoomName,
   joinChannel,
   usersLeave,
+  usersJoin,
 } from 'src/utils/socket/SocketRoom';
 
 const secondInMilliseconds = 1000;
@@ -146,7 +147,11 @@ export class ChatGateway implements OnGatewayConnection {
     const roomId = createdRoom.id;
 
     // [作成されたチャットルームにjoin]
-    await this.usersJoin(user.id, 'ChatRoom', roomId);
+    await usersJoin(
+      this.server,
+      user.id,
+      generateFullRoomName('ChatRoom', roomId)
+    );
 
     // [新しいチャットルームが作成されたことを通知する]
     this.sendResults(
@@ -266,7 +271,11 @@ export class ChatGateway implements OnGatewayConnection {
     }
 
     // [roomへのjoin状態をハードリレーションに同期させる]
-    await this.usersJoin(user.id, 'ChatRoom', roomId);
+    await usersJoin(
+      this.server,
+      user.id,
+      generateFullRoomName('ChatRoom', roomId)
+    );
     // 入室したことを通知
     this.sendResults(
       'ft_join',
@@ -674,29 +683,6 @@ export class ChatGateway implements OnGatewayConnection {
   private socketsInUserChannel(userId: number) {
     const fullUserRoomName = generateFullRoomName('User', userId);
     return this.server.in(fullUserRoomName);
-  }
-
-  //TODO ゲーム側にもつかえるので切り分けたい
-  /**
-   * 指定したユーザIDに対応するクライアントを指定したルームにjoinさせる\
-   * **あらかじめユーザルーム(${userId})にjoinしているクライアントにしか効果がないことに注意！！**
-   * @param userId
-   * @param roomType
-   * @param roomName
-   */
-  private async usersJoin(
-    userId: number,
-    roomType: 'ChatRoom' | 'User' | 'Global',
-    roomName: any
-  ) {
-    const fullUserRoomName = generateFullRoomName('User', userId);
-    const fullChatRoomName = generateFullRoomName(roomType, roomName);
-    const socks = await this.server.in(fullUserRoomName).allSockets();
-    console.log(
-      `joining clients in ${fullUserRoomName} -> ${fullChatRoomName}`,
-      socks
-    );
-    this.server.in(fullUserRoomName).socketsJoin(fullChatRoomName);
   }
 
   private async sendResults(

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -66,15 +66,15 @@ export class ChatGateway implements OnGatewayConnection {
     const userId = user.id;
     // [システムチャンネルへのjoin]
     //TODO チャットに依存しない機能になりそう
-    joinChannel(client, generateFullRoomName('User', userId));
-    joinChannel(client, generateFullRoomName('Global', 'global'));
+    joinChannel(client, generateFullRoomName({ userId }));
+    joinChannel(client, generateFullRoomName({ global: 'global' }));
 
     // [ユーザがjoinしているチャットルーム(ハードリレーション)の取得]
     const joiningRooms = (
       await this.chatRoomService.getRoomsJoining(userId)
     ).map((r) => r.chatRoom);
     const joiningRoomNames = joiningRooms.map((r) =>
-      generateFullRoomName('ChatRoom', r.id)
+      generateFullRoomName({ roomId: r.id })
     );
     console.log(`user ${userId} is joining to: [${joiningRoomNames}]`);
 
@@ -148,11 +148,7 @@ export class ChatGateway implements OnGatewayConnection {
     const roomId = createdRoom.id;
 
     // [作成されたチャットルームにjoin]
-    await usersJoin(
-      this.server,
-      user.id,
-      generateFullRoomName('ChatRoom', roomId)
-    );
+    await usersJoin(this.server, user.id, generateFullRoomName({ roomId }));
 
     // [新しいチャットルームが作成されたことを通知する]
     this.sendResults(
@@ -272,11 +268,7 @@ export class ChatGateway implements OnGatewayConnection {
     }
 
     // [roomへのjoin状態をハードリレーションに同期させる]
-    await usersJoin(
-      this.server,
-      user.id,
-      generateFullRoomName('ChatRoom', roomId)
-    );
+    await usersJoin(this.server, user.id, generateFullRoomName({ roomId }));
     // 入室したことを通知
     this.sendResults(
       'ft_join',
@@ -341,11 +333,7 @@ export class ChatGateway implements OnGatewayConnection {
     await this.chatRoomService.removeMember(roomId, user.id);
 
     // [roomへのjoin状態をハードリレーションに同期させる]
-    await usersLeave(
-      this.server,
-      user.id,
-      generateFullRoomName('ChatRoom', roomId)
-    );
+    await usersLeave(this.server, user.id, generateFullRoomName({ roomId }));
     this.sendResults(
       'ft_leave',
       {
@@ -466,7 +454,7 @@ export class ChatGateway implements OnGatewayConnection {
     await usersLeave(
       this.server,
       targetUser.id,
-      generateFullRoomName('ChatRoom', roomId)
+      generateFullRoomName({ roomId })
     );
     this.sendResults(
       'ft_kick',
@@ -682,7 +670,7 @@ export class ChatGateway implements OnGatewayConnection {
   }
 
   private socketsInUserChannel(userId: number) {
-    const fullUserRoomName = generateFullRoomName('User', userId);
+    const fullUserRoomName = generateFullRoomName({ userId });
     return this.server.in(fullUserRoomName);
   }
 
@@ -700,7 +688,7 @@ export class ChatGateway implements OnGatewayConnection {
       await sendResultRoom(
         this.server,
         op,
-        generateFullRoomName('User', target.userId),
+        generateFullRoomName({ userId: target.userId }),
         payload
       );
     }
@@ -708,7 +696,7 @@ export class ChatGateway implements OnGatewayConnection {
       await sendResultRoom(
         this.server,
         op,
-        generateFullRoomName('ChatRoom', target.roomId),
+        generateFullRoomName({ roomId: target.roomId }),
         payload
       );
     }
@@ -716,7 +704,7 @@ export class ChatGateway implements OnGatewayConnection {
       await sendResultRoom(
         this.server,
         op,
-        generateFullRoomName('Global', target.global),
+        generateFullRoomName({ global: target.global }),
         payload
       );
     }

--- a/backend/src/types/RoomType.ts
+++ b/backend/src/types/RoomType.ts
@@ -1,0 +1,1 @@
+export type RoomType = 'ChatRoom' | 'User' | 'Global';

--- a/backend/src/types/RoomType.ts
+++ b/backend/src/types/RoomType.ts
@@ -1,1 +1,3 @@
 export type RoomType = 'ChatRoom' | 'User' | 'Global';
+
+export type RoomName = string;

--- a/backend/src/types/RoomType.ts
+++ b/backend/src/types/RoomType.ts
@@ -1,3 +1,8 @@
 export type RoomType = 'ChatRoom' | 'User' | 'Global';
 
 export type RoomName = string;
+
+export type RoomArg =
+  | { roomId: number }
+  | { userId: number }
+  | { global: string };

--- a/backend/src/utils/socket/SocketRoom.ts
+++ b/backend/src/utils/socket/SocketRoom.ts
@@ -1,0 +1,19 @@
+import { RoomType } from 'src/types/RoomType';
+
+/**
+ * システムが使うルーム名
+ * @param roomType
+ * @param roomName
+ * @returns
+ */
+export const generateFullRoomName = (
+  roomType: RoomType,
+  roomName: string | number
+) => {
+  const roomSuffix = {
+    ChatRoom: '#',
+    User: '$',
+    Global: '%',
+  }[roomType];
+  return `${roomSuffix}${roomName}`;
+};

--- a/backend/src/utils/socket/SocketRoom.ts
+++ b/backend/src/utils/socket/SocketRoom.ts
@@ -74,3 +74,25 @@ export const usersLeave = async (
   console.log(`leaving clients in ${fullUserRoomName} from ${roomName}`, socks);
   server.in(fullUserRoomName).socketsLeave(roomName);
 };
+
+/**
+ * サーバからクライアントに向かってデータを流す
+ * @param server
+ * サーバー
+ * @param op
+ * イベント名
+ * @param roomName
+ * 対象の部屋名
+ * @param payload
+ * データ本体
+ */
+export const sendResultRoom = async (
+  server: Server,
+  op: string,
+  roomName: RoomName,
+  payload: any
+) => {
+  const socks = await server.to(roomName).allSockets();
+  console.log('sending downlink to:', roomName, op, payload, socks);
+  server.to(roomName).emit(op, payload);
+};

--- a/backend/src/utils/socket/SocketRoom.ts
+++ b/backend/src/utils/socket/SocketRoom.ts
@@ -1,5 +1,5 @@
 import { RoomType, RoomName } from 'src/types/RoomType';
-import { Socket } from 'socket.io';
+import { Socket, Server } from 'socket.io';
 
 /**
  * システムが使うルーム名
@@ -32,4 +32,24 @@ export const generateFullRoomName = (
 export const joinChannel = (client: Socket, roomName: RoomName) => {
   client.join(roomName);
   console.log(`client ${client.id} joined to ${roomName}`);
+};
+
+//TODO (英語としておかしいので名前を変える)
+/**
+ * @param server
+ * サーバー
+ * @param userId
+ * 対象のユーザー
+ * @param roomName
+ * 対象の部屋名
+ */
+export const usersLeave = async (
+  server: Server,
+  userId: number,
+  roomName: RoomName
+) => {
+  const fullUserRoomName = generateFullRoomName('User', userId);
+  const socks = await server.in(fullUserRoomName).allSockets();
+  console.log(`leaving clients in ${fullUserRoomName} from ${roomName}`, socks);
+  server.in(fullUserRoomName).socketsLeave(roomName);
 };

--- a/backend/src/utils/socket/SocketRoom.ts
+++ b/backend/src/utils/socket/SocketRoom.ts
@@ -1,4 +1,4 @@
-import { RoomType } from 'src/types/RoomType';
+import { RoomType, RoomName } from 'src/types/RoomType';
 import { Socket } from 'socket.io';
 
 /**
@@ -29,12 +29,7 @@ export const generateFullRoomName = (
  * 参加するルームの名前
  * @returns
  */
-export const joinChannel = (
-  client: Socket,
-  roomType: RoomType,
-  roomName: string | number
-) => {
-  const fullRoomName = generateFullRoomName(roomType, roomName);
-  client.join(fullRoomName);
-  console.log(`client ${client.id} joined to ${fullRoomName}`);
+export const joinChannel = (client: Socket, roomName: RoomName) => {
+  client.join(roomName);
+  console.log(`client ${client.id} joined to ${roomName}`);
 };

--- a/backend/src/utils/socket/SocketRoom.ts
+++ b/backend/src/utils/socket/SocketRoom.ts
@@ -22,7 +22,7 @@ export const generateFullRoomName = (roomArg: RoomArg): RoomName => {
     return addRoomTypePrefix('User', roomArg.userId);
   else if ('global' in roomArg)
     return addRoomTypePrefix('Global', roomArg.global);
-  return 'Error';
+  else throw new Error('Invalid RoomType');
 };
 
 /**

--- a/backend/src/utils/socket/SocketRoom.ts
+++ b/backend/src/utils/socket/SocketRoom.ts
@@ -34,6 +34,27 @@ export const joinChannel = (client: Socket, roomName: RoomName) => {
   console.log(`client ${client.id} joined to ${roomName}`);
 };
 
+/**
+ * 指定したユーザIDに対応するクライアントを指定したルームにjoinさせる\
+ * **あらかじめユーザルーム(${userId})にjoinしているクライアントにしか効果がないことに注意！！**
+ * @param server
+ * サーバー
+ * @param userId
+ * 対象のユーザー
+ * @param roomName
+ * 対象の部屋名
+ */
+export const usersJoin = async (
+  server: Server,
+  userId: number,
+  roomName: RoomName
+) => {
+  const fullUserRoomName = generateFullRoomName('User', userId);
+  const socks = await server.in(fullUserRoomName).allSockets();
+  console.log(`joining clients in ${fullUserRoomName} -> ${roomName}`, socks);
+  server.in(fullUserRoomName).socketsJoin(roomName);
+};
+
 //TODO (英語としておかしいので名前を変える)
 /**
  * @param server

--- a/backend/src/utils/socket/SocketRoom.ts
+++ b/backend/src/utils/socket/SocketRoom.ts
@@ -1,4 +1,5 @@
 import { RoomType } from 'src/types/RoomType';
+import { Socket } from 'socket.io';
 
 /**
  * システムが使うルーム名
@@ -16,4 +17,24 @@ export const generateFullRoomName = (
     Global: '%',
   }[roomType];
   return `${roomSuffix}${roomName}`;
+};
+
+/**
+ * Socketをルームに追加する
+ * @param client
+ * 対象のソケット
+ * @param roomType
+ * 参加するルームのタイプ
+ * @param roomName
+ * 参加するルームの名前
+ * @returns
+ */
+export const joinChannel = (
+  client: Socket,
+  roomType: RoomType,
+  roomName: string | number
+) => {
+  const fullRoomName = generateFullRoomName(roomType, roomName);
+  client.join(fullRoomName);
+  console.log(`client ${client.id} joined to ${fullRoomName}`);
 };


### PR DESCRIPTION
## やったこと
ソケットルームを扱うにあたって便利そうな関数を切り出した
- generateFullRoomName,
- joinChannel,
- usersLeave,
- usersJoin,
- sendResultRoom,

## やってないこと
- trapAuthの切り出し(ゲーム側でもuserIdが欲しいので後で切りだす)
- usersleaveの関数名変更