### PR TITLE
bugfix: ログアウト時にソケットがすぐに破棄されない

### DIFF
--- a/frontend/src/atoms.ts
+++ b/frontend/src/atoms.ts
@@ -1,4 +1,4 @@
-import { atom, useAtom } from 'jotai';
+import { atom } from 'jotai';
 import { UserPersonalData } from '@/components/AuthCard';
 import { AppCredential } from './hooks';
 import { io } from 'socket.io-client';
@@ -10,11 +10,16 @@ import * as TD from './typedef';
  */
 export const authFlowStateAtom = atom<AuthenticationFlowState>('Neutral');
 
+const personalDataAtom = atom<UserPersonalData | null>(null);
 export const userAtoms = {
   /**
    * ユーザデータのAtom
    */
-  personalDataAtom: atom<UserPersonalData | null>(null),
+  personalDataAtom,
+  userIdAtom: atom<number>((get) => {
+    const pd: UserPersonalData | null = get(personalDataAtom);
+    return pd ? pd.id : -1;
+  }),
 
   // 見えているチャットルームの一覧
   visibleRoomsAtom: atom<TD.ChatRoom[]>([]),
@@ -82,7 +87,7 @@ export const storedCredentialAtom = atom(
   }
 );
 
-const chatSocketFromCredential = (credential: AppCredential | null) => {
+export const chatSocketFromCredential = (credential: AppCredential | null) => {
   if (!credential) {
     return null;
   }
@@ -95,6 +100,4 @@ const chatSocketFromCredential = (credential: AppCredential | null) => {
 /**
  * ユーザに紐づくチャットWSのAtom
  */
-export const chatSocketAtom = atom((get) =>
-  chatSocketFromCredential(get(storedCredentialAtom))
-);
+export const chatSocketAtom = atom<ReturnType<typeof io> | null>(null);

--- a/frontend/src/routes/SocketHolder.tsx
+++ b/frontend/src/routes/SocketHolder.tsx
@@ -1,4 +1,9 @@
-import { chatSocketAtom, userAtoms } from '@/atoms';
+import {
+  chatSocketAtom,
+  chatSocketFromCredential,
+  storedCredentialAtom,
+  userAtoms,
+} from '@/atoms';
 import { useAtom } from 'jotai';
 import { useEffect } from 'react';
 import * as TD from '../typedef';
@@ -7,16 +12,24 @@ import * as Utils from '@/utils';
 export const SocketHolder = () => {
   // 「ソケット」
   // 認証されていない場合はnull
-  const [mySocket] = useAtom(chatSocketAtom);
+  const [mySocket, setMySocket] = useAtom(chatSocketAtom);
+  const [credential] = useAtom(storedCredentialAtom);
 
   // 認証フローのチェックと状態遷移
-  const [personalData] = useAtom(userAtoms.personalDataAtom);
+  const [userId] = useAtom(userAtoms.userIdAtom);
   const setVisibleRooms = useAtom(userAtoms.visibleRoomsAtom)[1];
   const setJoiningRooms = useAtom(userAtoms.joiningRoomsAtom)[1];
   const setFocusedRoomId = useAtom(userAtoms.focusedRoomIdAtom)[1];
   const setMessagesInRoom = useAtom(userAtoms.messagesInRoomAtom)[1];
   const setMembersInRoom = useAtom(userAtoms.membersInRoomAtom)[1];
-  const userId = personalData ? personalData.id : -1;
+
+  useEffect(() => {
+    if (mySocket) {
+      mySocket.close();
+    }
+    setMySocket(chatSocketFromCredential(credential));
+    // personalData を監視すると名前などの変更に反応するので, userId を監視する
+  }, [userId]);
 
   useEffect(() => {
     console.log('mySocket?', !!mySocket);


### PR DESCRIPTION
resolve #68 

---

`SocketHolder`コンポーネント上で「ログインユーザID」の切り替わりを感知してソケットを切り替える。

ソケット切り替えを、ログインユーザ情報atomのsetterでやるのもいいかと思ったが、setterが1回だけしか実行されない保証が特になさそうなので、
コンポーネント上でやることにした。