### PR TITLE
bugfix: 自分がチャットルームメンバー一覧に出なくなることがある

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -374,20 +374,37 @@ export class ChatGateway implements OnGatewayConnection {
       }
     );
     // チャットルームの内容を通知
-    const messages = await this.chatRoomService.getMessages({
-      roomId,
-      take: 50,
+    await Utils.PromiseMap({
+      messages: (async () => {
+        const messages = await this.chatRoomService.getMessages({
+          roomId,
+          take: 50,
+        });
+        this.sendResults(
+          'ft_get_room_messages',
+          {
+            id: roomId,
+            messages,
+          },
+          {
+            client,
+          }
+        );
+      })(),
+      members: (async () => {
+        const members = await this.chatRoomService.getMembers(roomId);
+        this.sendResults(
+          'ft_get_room_members',
+          {
+            id: roomId,
+            members,
+          },
+          {
+            client,
+          }
+        );
+      })(),
     });
-    this.sendResults(
-      'ft_get_room_messages',
-      {
-        id: roomId,
-        messages,
-      },
-      {
-        client,
-      }
-    );
     this.updateHeartbeat(user.id);
   }
 

--- a/backend/src/utils/socket/SocketRoom.ts
+++ b/backend/src/utils/socket/SocketRoom.ts
@@ -101,6 +101,6 @@ export const sendResultRoom = async (
   payload: any
 ) => {
   const socks = await server.to(roomName).allSockets();
-  // console.log('sending downlink to:', roomName, op, payload, socks);
+  console.log('sending downlink to:', roomName, op, payload, socks);
   server.to(roomName).emit(op, payload);
 };


### PR DESCRIPTION
## 現象

1. ユーザAがチャットルームXにjoinする
2. ユーザAがチャットルームXに1度もフォーカスしていない状態で, ユーザBがチャットルームXにjoinする
3. ユーザAがチャットルームXにフォーカスする
4. ユーザAの画面で, チャットルームXのメンバー一覧にはユーザBのみが表示される。

本来はユーザAもメンバー一覧に入っているはず。

## 原因

メンバー一覧の初期データは「メンバー数が0のルームにフォーカスすると`get_room_members`コマンドが送信される」という処理で取得していたが、フォーカス前にメンバー数が1以上になってしまうとこの処理は動かない。

## 修正

`join`時にその時点でのメンバーも取得して送信する。
