### PR TITLE
importのソートが一回で終わらない時の対応

### DIFF
--- a/.config/.husky/pre-commit
+++ b/.config/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 echo "lint and format staged file."
-(cd ./frontend && npx lint-staged) && (cd ./backend && npx lint-staged)
+(cd ./frontend && npx lint-staged --no-stash) && (cd ./backend && npx lint-staged --no-stash)


### PR DESCRIPTION
https://github.com/JUNNETWORKS/42-ft_transcendence/pull/88#issuecomment-1321360453
の対応。
問題共有と、あんまりいけてない暫定的な修正案としてPRだします

[eslint-plugin-import](https://github.com/import-js/eslint-plugin-import)は、一回のlint実行で全ての問題を修正できないことがあるみたいです
開発側もこれを許容しているようなので、対策としては以下のようなものしかないかなぁという感じです
- `npx eslint --fix src/hogehoge.ts`を問題が全て解決するまで繰り返す
- エディターでformatOnSaveを有効にする（こまめに保存すれば、そこまで頻繁に起きる問題でない気がするので
- eslint-plugin-importを使わない

このPRでは、commit時のlintで失敗した時に、lintで修正されたファイルをcommit前の状態に戻す設定を無効化しています
この変更で、commit時のlintに失敗してもlinterの修正自体はそのまま残るので、問題が全て修正されるまで複数回commit(+lint)を繰り返せるようになります
