### PR TITLE
Revert "feat: lint-stagedのstashを無効化"

### DIFF
--- a/.config/.husky/pre-commit
+++ b/.config/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 echo "lint and format staged file."
-(cd ./frontend && npx lint-staged --no-stash) && (cd ./backend && npx lint-staged --no-stash)
+(cd ./frontend && npx lint-staged) && (cd ./backend && npx lint-staged)


### PR DESCRIPTION
This reverts commit 8a9efc43084638e1dee3e02cd773e1a6546e719c.

commit時のlintの設定の変更を取り消します。
linterがエラーを出したときは、CLIからeslintの実行をお願いします。