### PR TITLE
レーティングDBスキーマ

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -123,5 +123,5 @@ model ChatMessage {
 model MatchRate {
   user   User @relation(fields: [userId], references: [id])
   userId Int  @id
-  rate   Int
+  rate   Int  @default(1500)
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,22 +11,23 @@ datasource db {
 }
 
 model User {
-  id                Int                 @id @default(autoincrement())
-  email             String              @unique
-  displayName       String              @unique
-  intraId           Int                 @unique
-  invalidateTokenIssuedBefore  DateTime?
-  password          String
-  isEnabledAvatar   Boolean             @default(false)
-  isEnabled2FA      Boolean             @default(false)
-  chatMessage       ChatMessage[]
-  joinedRoom        ChatUserRelation[]
-  ownedRoom         ChatRoom[]
-  chatroomAttribute ChatUserAttribute[]
-  followingUser     FriendRelation[]    @relation("followingUser")
-  followedUser      FriendRelation[]    @relation("followedUser")
-  blockingUser      BlockRelation[]     @relation("blockingUser")
-  blockedUser       BlockRelation[]     @relation("blockedUser")
+  id                          Int                 @id @default(autoincrement())
+  email                       String              @unique
+  displayName                 String              @unique
+  intraId                     Int                 @unique
+  invalidateTokenIssuedBefore DateTime?
+  password                    String
+  isEnabledAvatar             Boolean             @default(false)
+  isEnabled2FA                Boolean             @default(false)
+  chatMessage                 ChatMessage[]
+  joinedRoom                  ChatUserRelation[]
+  ownedRoom                   ChatRoom[]
+  chatroomAttribute           ChatUserAttribute[]
+  followingUser               FriendRelation[]    @relation("followingUser")
+  followedUser                FriendRelation[]    @relation("followedUser")
+  blockingUser                BlockRelation[]     @relation("blockingUser")
+  blockedUser                 BlockRelation[]     @relation("blockedUser")
+  MatchRate                   MatchRate[]
 }
 
 model UserAvatar {
@@ -117,4 +118,10 @@ model ChatMessage {
   userId     Int?
   createdAt  DateTime @default(now())
   content    String
+}
+
+model MatchRate {
+  user   User @relation(fields: [userId], references: [id])
+  userId Int  @id
+  rate   Int
 }


### PR DESCRIPTION
マッチのレーティングに必要なスキーマをたたき台として追加。

モデルに対して最低限必要そうなインターフェイス
- ユーザーのレーティングを取得
- マッチ終了後、二人のユーザーのレート変動を更新
- レート上位のユーザーをまとめて取得

モデルをUserと分ける場合、ユーザー作成時にレーティングのレコードを作成する必要がありそう。