### PR TITLE
Feature/invite private #102

### DIFF
--- a/backend/src/chat/dto/operation-invite.dto.ts
+++ b/backend/src/chat/dto/operation-invite.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsInt } from 'class-validator';
+
+export class OperationInviteDto {
+  @IsNotEmpty()
+  @Type(() => Number)
+  @IsInt()
+  @ApiProperty()
+  roomId!: number;
+
+  users: number[];
+}

--- a/backend/src/chatrooms/chatrooms.service.ts
+++ b/backend/src/chatrooms/chatrooms.service.ts
@@ -282,6 +282,13 @@ export class ChatroomsService {
     });
   }
 
+  // usersに指定したユーザーをmemberとしてルームに追加する
+  async addMembers(chatRoomId: number, users: number[]) {
+    return await this.prisma.chatUserRelation.createMany({
+      data: users.map((userId) => ({ chatRoomId, userId })),
+    });
+  }
+
   async updateMember(chatRoomId: number, roomMemberDto: RoomMemberDto) {
     // ONWERはmemberTypeを変更できない。
     const { userId, memberType } = roomMemberDto;


### PR DESCRIPTION
resolve: #102 

やりたいこと
- (B) privateルームのオーナーが選んだ複数のユーザーをチャットルームにジョインさせるwsコマンド
  - とりあえずft_inviteで実装中
  - ブロックしているユーザーからの招待は無視するべき？

- (F) privateルームのメンバー一覧のあたりに招待ボタンを追加
- (F) 招待ボタンからユーザーを選択するモーダルを表示
- (F) ユーザーを選択するUIを追加する
  - どのようなユーザーを表示するか、follow or 全ユーザー
  - テキスト検索が必要？
 
 