### PR TITLE
認証関連処理の一部に最低所要時間をつける

### DIFF
--- a/backend/src/auth/auth-utils.ts
+++ b/backend/src/auth/auth-utils.ts
@@ -1,0 +1,75 @@
+/**
+ * `asyncProc`が, 少なくとも`leastDurationInMs`ミリ秒経ってから解決されるようにする.
+ * @param leastDurationInMs 最小経過時間
+ * @param asyncProc 非同期処理
+ * @returns
+ */
+export async function stall<U>(
+  leastDurationInMs: number,
+  asyncProc: () => Promise<U>
+): Promise<U> {
+  return new Promise<U>((res, rej) => {
+    let returnValue: { data: U } | null = null;
+    let errorValue: { error: any } | null = null;
+    let timedOut = false;
+    let finished = false;
+
+    // この timeout が終了するまで resolve も reject もされない
+    setTimeout(() => {
+      timedOut = true;
+
+      if (finished) {
+        return;
+      }
+      if (errorValue) {
+        returnValue = null;
+        finished = true;
+        rej(errorValue.error);
+      } else if (returnValue) {
+        errorValue = null;
+        finished = true;
+        res(returnValue.data);
+      }
+    }, leastDurationInMs);
+
+    try {
+      asyncProc().then(
+        (result) => {
+          returnValue = { data: result };
+          if (!timedOut) {
+            return;
+          }
+          if (finished) {
+            return;
+          }
+          errorValue = null;
+          finished = true;
+          res(returnValue.data);
+        },
+        (e) => {
+          errorValue = { error: e };
+          if (!timedOut) {
+            return;
+          }
+          if (finished) {
+            return;
+          }
+          returnValue = null;
+          finished = true;
+          rej(errorValue.error);
+        }
+      );
+    } catch (e) {
+      errorValue = { error: e };
+      if (!timedOut) {
+        return;
+      }
+      if (finished) {
+        return;
+      }
+      returnValue = null;
+      finished = true;
+      rej(errorValue.error);
+    }
+  });
+}

--- a/backend/src/auth/jwt-totp.strategy.ts
+++ b/backend/src/auth/jwt-totp.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
+import { stall } from './auth-utils';
 import { jwtConstants } from './auth.constants';
 
 // Strategy をどこからインポートするかが重要
@@ -22,14 +23,16 @@ export class JwtTotpStrategy extends PassportStrategy(Strategy, 'jwt-totp') {
   }
 
   async validate(payload: any) {
-    // validate にはデコード済みのJWTのペイロードが渡ってくる.
-    // 主張 = ペイロードの中身
-    // 検証 = 署名が正しいことの確認
-    // TODO: JWTの鍵をユーザごとに変える方法はあるだろうか?
-    if (payload.next !== 'totp') {
-      console.log('invalid');
-      throw new UnauthorizedException('invalid');
-    }
-    return { secretId: payload.secretId };
+    return stall(500, async () => {
+      // validate にはデコード済みのJWTのペイロードが渡ってくる.
+      // 主張 = ペイロードの中身
+      // 検証 = 署名が正しいことの確認
+      // TODO: JWTの鍵をユーザごとに変える方法はあるだろうか?
+      if (payload.next !== 'totp') {
+        console.log('invalid');
+        throw new UnauthorizedException('invalid');
+      }
+      return { secretId: payload.secretId };
+    });
   }
 }

--- a/backend/src/auth/local.strategy.ts
+++ b/backend/src/auth/local.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
 
+import { stall } from './auth-utils';
 import { AuthService } from './auth.service';
 
 @Injectable()
@@ -13,10 +14,12 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(email: string, password: string): Promise<any> {
-    const user = await this.authService.validateUser(email, password);
-    if (!user) {
-      throw new UnauthorizedException();
-    }
-    return user;
+    return stall(500, async () => {
+      const user = await this.authService.validateUser(email, password);
+      if (!user) {
+        throw new UnauthorizedException();
+      }
+      return user;
+    });
   }
 }


### PR DESCRIPTION
### 目的

- 総当たり攻撃に対する時間稼ぎ
- タイミング攻撃の妨害(効果ある？)
- 認証してる感を出す

### タスクリスト

- [x] (B) `stall`関数を実装
- [x] (B) パスワード認証ガードに500msの最低処理時間を適用
- [x] (B) TOTP認証ガードに500msの最低処理時間を適用
  - ケータイの電池が切れて未確認