### PR TITLE
186 現在のランキングを表示できるようにする

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -15,8 +15,13 @@ async function main() {
       intraId: 2,
     },
     { displayName: 'yokawada', email: 'yokawada@prisma.io', intraId: 3 },
-    { displayName: 'badass', email: 'badass@prisma.io', intraId: 4 },
-  ].reduce((prev: Promise<User[]>, d) => {
+    { displayName: 'Lorem', email: 'Lorem@prisma.io', intraId: 4 },
+    { displayName: 'ipsum', email: 'ipsum@prisma.io', intraId: 5 },
+    { displayName: 'dolor', email: 'dolor@prisma.io', intraId: 6 },
+    { displayName: 'sit', email: 'sit@prisma.io', intraId: 7 },
+    { displayName: 'amet', email: 'amet@prisma.io', intraId: 8 },
+    { displayName: 'consectetur', email: 'badass@prisma.io', intraId: 9 },
+  ].reduce((prev: Promise<User[]>, d, i) => {
     return prev.then((leadings) => {
       return prisma.user
         .create({
@@ -24,7 +29,9 @@ async function main() {
             ...d,
             password: UsersService.hash_password(d.displayName),
             userRankPoint: {
-              create: {},
+              create: {
+                rankPoint: 100 * i,
+              },
             },
           },
         })

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -1,7 +1,5 @@
 import { Injectable } from '@nestjs/common';
 
-import { pick } from 'src/utils';
-
 import { PrismaService } from '../prisma/prisma.service';
 import { OnlineMatch } from './game/online-match';
 
@@ -63,6 +61,6 @@ export class PongService {
         },
       },
     });
-    return results.map((result) => pick(result, 'rankPoint', 'user'));
+    return results;
   }
 }

--- a/frontend/src/features/Pong/components/PongRanking.tsx
+++ b/frontend/src/features/Pong/components/PongRanking.tsx
@@ -4,16 +4,8 @@ import { useManualErrorBoundary } from '@/components/ManualErrorBoundary';
 import { APIError } from '@/errors/APIError';
 import { useAPICallerWithCredential } from '@/hooks/useAPICaller';
 
+import { UserForRanking } from '../types';
 import { RankingCard } from './RankingCard';
-
-type UserForRanking = {
-  rankPoint: number;
-  user: {
-    displayName: string;
-    id: number;
-    isEnabledAvatar: true;
-  };
-};
 
 const RenderRanking = ({
   ranking,
@@ -41,11 +33,13 @@ const RenderRanking = ({
   }
   return (
     <ul className="mt-2 flex flex-col gap-3">
-      <RankingCard id={1} />
-      <RankingCard id={2} />
-      <RankingCard id={3} />
-      <RankingCard id={4} />
-      <RankingCard id={5} />
+      {ranking &&
+        ranking.map((item, index) => {
+          const rankPlace = index + 1; //index０が1位なので1足して調整
+          return (
+            <RankingCard key={item.user.id} rankPlace={rankPlace} user={item} />
+          );
+        })}
     </ul>
   );
 };

--- a/frontend/src/features/Pong/components/PongRanking.tsx
+++ b/frontend/src/features/Pong/components/PongRanking.tsx
@@ -53,7 +53,7 @@ export const PongRanking = () => {
   };
 
   return (
-    <div className="grow-[1]">
+    <div className="overflow-hidden">
       <p className="text-5xl font-bold leading-tight">Ranking</p>
       <div className=" h-2 w-[360] bg-primary"></div>
       <ErrorBoundary>

--- a/frontend/src/features/Pong/components/PongRanking.tsx
+++ b/frontend/src/features/Pong/components/PongRanking.tsx
@@ -32,7 +32,7 @@ const RenderRanking = ({
     })();
   }
   return (
-    <ul className="mt-2 flex flex-col gap-3">
+    <ul className="mt-2 flex max-h-[60vh] flex-col gap-3 overflow-scroll">
       {ranking &&
         ranking.map((item, index) => {
           const rankPlace = index + 1; //index０が1位なので1足して調整

--- a/frontend/src/features/Pong/components/PongRanking.tsx
+++ b/frontend/src/features/Pong/components/PongRanking.tsx
@@ -1,0 +1,76 @@
+import { Suspense, useState } from 'react';
+
+import { useManualErrorBoundary } from '@/components/ManualErrorBoundary';
+import { APIError } from '@/errors/APIError';
+import { useAPICallerWithCredential } from '@/hooks/useAPICaller';
+
+import { RankingCard } from './RankingCard';
+
+type UserForRanking = {
+  rankPoint: number;
+  user: {
+    displayName: string;
+    id: number;
+    isEnabledAvatar: true;
+  };
+};
+
+const RenderRanking = ({
+  ranking,
+  setter,
+  onError,
+}: {
+  ranking: UserForRanking[] | null;
+  setter: (data: UserForRanking[]) => void;
+  onError: (e: unknown) => void;
+}) => {
+  const callAPI = useAPICallerWithCredential();
+  if (!ranking) {
+    throw (async () => {
+      try {
+        const result = await callAPI('GET', `/pong/ranking`);
+        if (!result.ok) {
+          throw new APIError(result.statusText, result);
+        }
+        const json = await result.json();
+        setter(json);
+      } catch (e) {
+        onError(e);
+      }
+    })();
+  }
+  return (
+    <ul className="mt-2 flex flex-col gap-3">
+      <RankingCard id={1} />
+      <RankingCard id={2} />
+      <RankingCard id={3} />
+      <RankingCard id={4} />
+      <RankingCard id={5} />
+    </ul>
+  );
+};
+
+export const PongRanking = () => {
+  const [userRanking, setUserRanking] = useState<UserForRanking[] | null>(null);
+  const [, setError, ErrorBoundary] = useManualErrorBoundary();
+
+  const setter = (data: UserForRanking[]) => {
+    setUserRanking(data);
+  };
+
+  return (
+    <div className="grow-[1]">
+      <p className="text-5xl font-bold leading-tight">Ranking</p>
+      <div className=" h-2 w-[360] bg-primary"></div>
+      <ErrorBoundary>
+        <Suspense fallback={<p>Loading...</p>}>
+          <RenderRanking
+            ranking={userRanking}
+            setter={setter}
+            onError={setError}
+          />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+};

--- a/frontend/src/features/Pong/components/RankingCard.tsx
+++ b/frontend/src/features/Pong/components/RankingCard.tsx
@@ -13,12 +13,14 @@ export const RankingCard = ({
 }) => {
   return (
     <li className="flex items-center gap-5 bg-secondary py-2 px-3">
-      <div className="w-16 text-4xl font-bold">{ordinal(rankPlace)}</div>
-      <UserAvatar className="h-16 w-16" user={user} />
-      <div className="max-w-[200px] grow truncate text-3xl">
-        {user.displayName}
+      <div className="w-16 shrink-0 text-4xl font-bold">
+        {ordinal(rankPlace)}
       </div>
-      <div className="text-xl">{rankPoint}RP</div>
+      <UserAvatar className="h-16 w-16 shrink-0" user={user} />
+      <div className="flex grow justify-between gap-5 overflow-hidden">
+        <div className="truncate text-3xl">{user.displayName}</div>
+        <div className="text-xl">{rankPoint}RP</div>
+      </div>
     </li>
   );
 };

--- a/frontend/src/features/Pong/components/RankingCard.tsx
+++ b/frontend/src/features/Pong/components/RankingCard.tsx
@@ -1,20 +1,22 @@
 import ordinal from 'ordinal';
 
-type Props = {
-  id: number;
-};
+import { UserForRanking } from '../types';
 
-export const RankingCard = ({ id }: Props) => {
-  //TODO ユーザー取得処理をいれる。
-  const name = 'Kizaru';
+export const RankingCard = ({
+  user: { rankPoint, user },
+  rankPlace,
+}: {
+  user: UserForRanking;
+  rankPlace: number;
+}) => {
+  //TODO ユーザー画像取得処理をいれる。
   const image = '/Kizaru.png';
-  const point = 1000;
   return (
     <li className="flex items-center gap-5 bg-secondary py-2 px-3">
-      <div className="w-16 text-4xl font-bold">{ordinal(id)}</div>
+      <div className="w-16 text-4xl font-bold">{ordinal(rankPlace)}</div>
       <img className="h-16 w-16" src={image}></img>
-      <div className="grow text-3xl">{name}</div>
-      <div className="text-xl">{point}RP</div>
+      <div className="grow text-3xl">{user.displayName}</div>
+      <div className="text-xl">{rankPoint}RP</div>
     </li>
   );
 };

--- a/frontend/src/features/Pong/components/RankingCard.tsx
+++ b/frontend/src/features/Pong/components/RankingCard.tsx
@@ -15,7 +15,9 @@ export const RankingCard = ({
     <li className="flex items-center gap-5 bg-secondary py-2 px-3">
       <div className="w-16 text-4xl font-bold">{ordinal(rankPlace)}</div>
       <UserAvatar className="h-16 w-16" user={user} />
-      <div className="grow text-3xl">{user.displayName}</div>
+      <div className="max-w-[200px] grow truncate text-3xl">
+        {user.displayName}
+      </div>
       <div className="text-xl">{rankPoint}RP</div>
     </li>
   );

--- a/frontend/src/features/Pong/components/RankingCard.tsx
+++ b/frontend/src/features/Pong/components/RankingCard.tsx
@@ -1,5 +1,7 @@
 import ordinal from 'ordinal';
 
+import { UserAvatar } from '@/components/UserAvater';
+
 import { UserForRanking } from '../types';
 
 export const RankingCard = ({
@@ -9,12 +11,10 @@ export const RankingCard = ({
   user: UserForRanking;
   rankPlace: number;
 }) => {
-  //TODO ユーザー画像取得処理をいれる。
-  const image = '/Kizaru.png';
   return (
     <li className="flex items-center gap-5 bg-secondary py-2 px-3">
       <div className="w-16 text-4xl font-bold">{ordinal(rankPlace)}</div>
-      <img className="h-16 w-16" src={image}></img>
+      <UserAvatar className="h-16 w-16" user={user} />
       <div className="grow text-3xl">{user.displayName}</div>
       <div className="text-xl">{rankPoint}RP</div>
     </li>

--- a/frontend/src/features/Pong/components/TopPage.tsx
+++ b/frontend/src/features/Pong/components/TopPage.tsx
@@ -5,8 +5,7 @@ import { io } from 'socket.io-client';
 import { Modal } from '@/components/Modal';
 
 import { CommandCard } from './CommandCard';
-import { RankingCard } from './RankingCard';
-
+import { PongRanking } from './PongRanking';
 
 export const PongTopPage = (props: { mySocket: ReturnType<typeof io> }) => {
   const { mySocket } = props;
@@ -61,17 +60,7 @@ export const PongTopPage = (props: { mySocket: ReturnType<typeof io> }) => {
             }}
           />
         </div>
-        <div className="grow-[1]">
-          <p className="text-5xl font-bold leading-tight">Ranking</p>
-          <div className=" h-2 w-[360] bg-primary"></div>
-          <ul className="mt-2 flex flex-col gap-3">
-            <RankingCard id={1} />
-            <RankingCard id={2} />
-            <RankingCard id={3} />
-            <RankingCard id={4} />
-            <RankingCard id={5} />
-          </ul>
-        </div>
+        <PongRanking />
       </div>
     </>
   );

--- a/frontend/src/features/Pong/components/TopPage.tsx
+++ b/frontend/src/features/Pong/components/TopPage.tsx
@@ -37,8 +37,8 @@ export const PongTopPage = (props: { mySocket: ReturnType<typeof io> }) => {
           </button>
         </div>
       </Modal>
-      <div className="mx-20 flex flex-1 items-center justify-center gap-20">
-        <div className="flex shrink-0 grow-[2] flex-col gap-8">
+      <div className="grid grid-cols-pongTopPage items-center justify-center gap-20 overflow-scroll px-20">
+        <div className="flex shrink-0 flex-col gap-10">
           <CommandCard
             text="カジュアルマッチをプレイ"
             onClick={() => {

--- a/frontend/src/features/Pong/components/TopPage.tsx
+++ b/frontend/src/features/Pong/components/TopPage.tsx
@@ -37,7 +37,7 @@ export const PongTopPage = (props: { mySocket: ReturnType<typeof io> }) => {
           </button>
         </div>
       </Modal>
-      <div className="grid grid-cols-pongTopPage items-center justify-center gap-20 overflow-scroll px-20">
+      <div className="grid grid-cols-pongTopPage items-center justify-center gap-20 overflow-scroll px-20 py-12">
         <div className="flex shrink-0 flex-col gap-10">
           <CommandCard
             text="カジュアルマッチをプレイ"

--- a/frontend/src/features/Pong/types/index.ts
+++ b/frontend/src/features/Pong/types/index.ts
@@ -1,3 +1,5 @@
+import { User } from '@/typedef';
+
 // サーバー側で保持しているゲーム中に変化しない情報
 // サーバーでの計算に用いる情報フィールドサイズ
 // これとcanvasサイズの比を書けて描画する｡
@@ -58,9 +60,5 @@ export type GameResult = {
 
 export type UserForRanking = {
   rankPoint: number;
-  user: {
-    displayName: string;
-    id: number;
-    isEnabledAvatar: true;
-  };
+  user: User;
 };

--- a/frontend/src/features/Pong/types/index.ts
+++ b/frontend/src/features/Pong/types/index.ts
@@ -55,3 +55,12 @@ export type GameResult = {
   winner: Player;
   loser: Player;
 };
+
+export type UserForRanking = {
+  rankPoint: number;
+  user: {
+    displayName: string;
+    id: number;
+    isEnabledAvatar: true;
+  };
+};

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -7,6 +7,9 @@ module.exports = {
     "./src/**/*.{js,ts,jsx,tsx}",],
   theme: {
     extend: {
+      gridTemplateColumns: {
+        'pongTopPage': 'minmax(500px, 1fr) minmax(400px, 1fr)',
+      },
       backgroundImage: {
         'navbar-img': "url('./src/assets/NavBar.svg')",
       },


### PR DESCRIPTION
## やったこと
 #186 (#183)の解決 (issue被ってた)

## 概要
- 下手がきだったRankingCardを、`PongRanking`コンポーネントで管理するようにした
- `PongRanking`コンポーネントでは、`/pong/ranking`からデータを取得して配置する。
- 長い名前が出る関係上、ページのレイアウトが崩れたので直した。
- ランキングを見るに当たって、ユーザー数とRankPointの差異が欲しかったので、seedをいじった

## スクショ
![スクリーンショット 2022-12-04 23 06 36](https://user-images.githubusercontent.com/62199197/205495164-3817238a-fd1a-475e-9a75-7a2a9dbc1281.png)
