### PR TITLE
マッチヒストリーを見やすくする

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { AppRoutes } from '@/routes/AppRoutes';
 
 import { UserCreatedFormHolder } from './features/DevAuth/UserCreatedFormHolder';
 import { ToastHolder } from './features/Toaster/ToastHolder';
+import { UserCardHolder } from './features/User/UserCardHolder';
 import { useConfirmModalComponent } from './hooks/useConfirmModal';
 
 import '../index.css';
@@ -19,6 +20,7 @@ export const App = () => {
       <ToastHolder />
       <ConfirmModal />
       <UserCreatedFormHolder />
+      <UserCardHolder />
     </AppProvider>
   );
 };

--- a/frontend/src/components/ChatMemberCard.tsx
+++ b/frontend/src/components/ChatMemberCard.tsx
@@ -1,14 +1,11 @@
-import { Popover } from '@headlessui/react';
-import { useState } from 'react';
-import { usePopper } from 'react-popper';
-
 import { FTButton, FTH4 } from '@/components/FTBasicComponents';
-import { UserCard } from '@/features/User/UserCard';
 import { InlineIcon } from '@/hocs/InlineIcon';
 import { Icons } from '@/icons';
+import { useUserCard } from '@/stores/control';
 import { useUserDataReadOnly } from '@/stores/store';
 import * as TD from '@/typedef';
 
+import { PopoverUserCard } from './PopoverUserCard';
 import { UserAvatar } from './UserAvater';
 
 export const AdminOperationBar = (props: {
@@ -95,45 +92,41 @@ export const ChatMemberCard = (props: {
     }
     return null;
   };
-  const [referenceElement, setReferenceElement] =
-    useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
-    null
+  const popoverContent = <AdminOperationBar {...props} />;
+  const oc = useUserCard();
+  const openCard = () => oc(user, popoverContent || null);
+  const avatarButton = (
+    <UserAvatar className="m-1 h-8 w-8" user={user} onClick={openCard} />
   );
-  const { styles, attributes } = usePopper(referenceElement, popperElement, {
-    placement: 'left-start',
-  });
   return (
-    <Popover className="relative">
-      <Popover.Button
-        className="flex w-full flex-row items-center hover:bg-teal-700"
-        ref={setReferenceElement}
+    <div className="flex w-full cursor-pointer flex-row items-center hover:bg-teal-700">
+      <div className="shrink-0 grow-0">
+        <PopoverUserCard button={avatarButton}>
+          {popoverContent}
+        </PopoverUserCard>
+      </div>
+      <PopoverUserCard
+        className="flex shrink grow flex-row items-center"
+        button={
+          <>
+            <div className="shrink-0 grow-0 cursor-pointer" onClick={openCard}>
+              <UserTypeCap />
+            </div>
+            <div
+              className={`shrink grow cursor-pointer ${
+                isYou ? 'font-bold' : ''
+              } max-w-[12em] overflow-hidden text-ellipsis whitespace-nowrap text-left`}
+              key={props.member.userId}
+              style={{ wordBreak: 'keep-all' }}
+              onClick={openCard}
+            >
+              {user.displayName}
+            </div>
+          </>
+        }
       >
-        <div className="shrink-0 grow-0">
-          <UserAvatar className="m-1 h-8 w-8" user={user} />
-        </div>
-        <UserTypeCap />
-        <div
-          className={`shrink grow cursor-pointer ${
-            isYou ? 'font-bold' : ''
-          } max-w-[10em] overflow-hidden text-ellipsis whitespace-nowrap text-left`}
-          key={props.member.userId}
-          style={{ wordBreak: 'keep-all' }}
-        >
-          {user.displayName}
-        </div>
-      </Popover.Button>
-
-      <Popover.Panel
-        className="absolute z-10 border-8 border-gray-500 bg-black/90"
-        ref={setPopperElement}
-        style={styles.popper}
-        {...attributes.popper}
-      >
-        <UserCard id={user.id}>
-          <AdminOperationBar {...props} />
-        </UserCard>
-      </Popover.Panel>
-    </Popover>
+        {popoverContent}
+      </PopoverUserCard>
+    </div>
   );
 };

--- a/frontend/src/components/ChatMessageCard.tsx
+++ b/frontend/src/components/ChatMessageCard.tsx
@@ -1,8 +1,7 @@
-import { Popover } from '@headlessui/react';
 import * as dayjs from 'dayjs';
 import { useAtom } from 'jotai';
 
-import { UserCard } from '@/features/User/UserCard';
+import { useUserCard } from '@/stores/control';
 import { useUserDataReadOnly } from '@/stores/store';
 import { dataAtom } from '@/stores/structure';
 import * as TD from '@/typedef';
@@ -24,6 +23,7 @@ export const ChatMessageCard = (props: {
   id: string;
 }) => {
   const user = useUserDataReadOnly(props.userId);
+  const openCard = useUserCard();
   const [blockingUsers] = useAtom(dataAtom.blockingUsers);
   const isBlocked =
     blockingUsers && blockingUsers.find((u) => u.id === props.message.userId);
@@ -31,21 +31,16 @@ export const ChatMessageCard = (props: {
     return null;
   }
   const avatarButton = (
-    <Popover.Button>
-      <UserAvatar
-        className="h-12 w-12 border-4 border-solid border-gray-600"
-        user={user}
-      />
-    </Popover.Button>
+    <UserAvatar
+      className="h-12 w-12 border-4 border-solid border-gray-600"
+      user={user}
+      onClick={() => openCard(user, popoverContent || null)}
+    />
   );
-  const popoverContent = (
-    <UserCard id={props.message.userId}>
-      <AdminOperationBar {...props} />
-    </UserCard>
-  );
+  const popoverContent = <AdminOperationBar {...props} />;
   return (
     <div
-      className="flex flex-row items-start px-2 py-1"
+      className="flex flex-row items-start px-2 py-1 hover:bg-gray-800"
       key={props.message.id}
       id={props.id}
     >

--- a/frontend/src/components/ChatSystemMessageCard.tsx
+++ b/frontend/src/components/ChatSystemMessageCard.tsx
@@ -1,7 +1,6 @@
 import * as dayjs from 'dayjs';
 import { useAtom } from 'jotai';
 
-import { UserCard } from '@/features/User/UserCard';
 import { InlineIcon } from '@/hocs/InlineIcon';
 import { Icons } from '@/icons';
 import { useUserDataReadOnly } from '@/stores/store';
@@ -125,7 +124,7 @@ export const ChatSystemMessageCard = (props: {
   }
   return (
     <div
-      className="flex flex-row items-start px-2 py-1 text-sm text-gray-400"
+      className="flex flex-row items-start px-2 py-1 text-sm text-gray-400 hover:bg-gray-800"
       key={props.message.id}
       id={props.id}
     >
@@ -136,20 +135,16 @@ export const ChatSystemMessageCard = (props: {
               message={props.message}
               PrimaryChild={() => (
                 <PopoverUserCard user={user}>
-                  <UserCard id={user.id}>
-                    <AdminOperationBar {...props} />
-                  </UserCard>
+                  <AdminOperationBar {...props} />
                 </PopoverUserCard>
               )}
               SecondaryChild={() =>
                 targetUser && (
                   <PopoverUserCard user={targetUser}>
-                    <UserCard id={targetUser.id}>
-                      <AdminOperationBar
-                        {...props}
-                        member={props.members[targetUser.id]}
-                      />
-                    </UserCard>
+                    <AdminOperationBar
+                      {...props}
+                      member={props.members[targetUser.id]}
+                    />
                   </PopoverUserCard>
                 )
               }

--- a/frontend/src/components/PopoverUserCard.tsx
+++ b/frontend/src/components/PopoverUserCard.tsx
@@ -1,45 +1,48 @@
-import { Popover } from '@headlessui/react';
-import { ReactNode, useState } from 'react';
-import { usePopper } from 'react-popper';
+import { ReactNode } from 'react';
 
+import { useUserCard } from '@/stores/control';
 import { User } from '@/typedef';
 
 type Prop = {
+  className?: string;
   user?: User;
   button?: ReactNode;
-  children: ReactNode;
+  children?: JSX.Element;
 };
 
-export const PopoverUserCard = ({ user, button, children }: Prop) => {
-  const [referenceElement, setReferenceElement] =
-    useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
-    null
-  );
-  const { styles, attributes } = usePopper(referenceElement, popperElement, {
-    placement: 'auto',
-  });
+export const PopoverUserCard = ({
+  className,
+  user,
+  button,
+  children,
+}: Prop) => {
+  const openCard = useUserCard();
   if (!user && !button) {
     return null;
   }
-  return (
-    <Popover className="relative inline-block">
-      {button || (
-        <Popover.Button
-          className="max-w-[20em] overflow-hidden text-ellipsis px-1 font-bold hover:underline"
-          ref={setReferenceElement}
+  const inner = () => {
+    if (button) {
+      return button;
+    }
+    if (user) {
+      return (
+        <div
+          className="max-w-[20em] overflow-hidden text-ellipsis px-1 align-middle font-bold hover:underline"
+          onClick={() => openCard(user, children || undefined)}
         >
-          {user?.displayName}
-        </Popover.Button>
-      )}
-      <Popover.Panel
-        className="absolute z-10 border-8 border-gray-500 bg-black/90"
-        ref={setPopperElement}
-        style={styles.popper}
-        {...attributes.popper}
-      >
-        {children}
-      </Popover.Panel>
-    </Popover>
+          {user.displayName}
+        </div>
+      );
+    }
+    return null;
+  };
+  return (
+    <div
+      className={`relative inline-block cursor-pointer align-middle ${
+        className || ''
+      }`}
+    >
+      {inner()}
+    </div>
   );
 };

--- a/frontend/src/components/UserAvater.tsx
+++ b/frontend/src/components/UserAvater.tsx
@@ -7,9 +7,10 @@ type Props = {
     avatarTime: number;
   };
   className?: string;
+  onClick?: () => void;
 };
 
-export const UserAvatar = ({ user, className }: Props) => {
+export const UserAvatar = ({ user, className, onClick }: Props) => {
   return (
     <img
       src={
@@ -18,7 +19,10 @@ export const UserAvatar = ({ user, className }: Props) => {
           : '/Kizaru.png'
       }
       alt="CurrentUserProfileImage"
-      className={`${className || 'm-3 h-14 w-14'} object-cover`}
+      className={`${className || 'm-3 h-14 w-14'} object-cover ${
+        onClick ? ' cursor-pointer' : ''
+      }`}
+      onClick={onClick}
     />
   );
 };

--- a/frontend/src/features/DevAuth/DevAuth.tsx
+++ b/frontend/src/features/DevAuth/DevAuth.tsx
@@ -6,7 +6,7 @@ import { toast } from 'react-toastify';
 import { Modal } from '@/components/Modal';
 import { useQuery } from '@/hooks';
 import { authAtom, useLoginLocal, useLogout } from '@/stores/auth';
-import { formAtom } from '@/stores/control';
+import { modalAtom } from '@/stores/control';
 
 import {
   verifyOAuth2AuthorizationCode,
@@ -41,7 +41,7 @@ export const DevAuth = () => {
   const loginLocal = useLoginLocal();
   const logout = useLogout();
   const [token2FA, setToken2FA] = useState<string | null>(null);
-  const [, setIsOpenCreatedForm] = useAtom(formAtom.isOpenCreateForm);
+  const [, setIsOpenCreatedForm] = useAtom(modalAtom.isOpenCreateForm);
 
   const anonymizeAuthFlow = () => {
     logout();

--- a/frontend/src/features/DevAuth/UserCreatedFormHolder.tsx
+++ b/frontend/src/features/DevAuth/UserCreatedFormHolder.tsx
@@ -1,13 +1,13 @@
 import { useAtom } from 'jotai';
 
 import { Modal } from '@/components/Modal';
-import { formAtom } from '@/stores/control';
+import { modalAtom } from '@/stores/control';
 
 import { UserCreatedForm } from '../User/UserCreatedForm';
 
 export const UserCreatedFormHolder = () => {
   const [isOpenCreatedForm, setIsOpenCreatedForm] = useAtom(
-    formAtom.isOpenCreateForm
+    modalAtom.isOpenCreateForm
   );
 
   return (

--- a/frontend/src/features/User/UserCardHolder.tsx
+++ b/frontend/src/features/User/UserCardHolder.tsx
@@ -1,0 +1,19 @@
+import { useAtom } from 'jotai';
+
+import { Modal } from '@/components/Modal';
+import { modalAtom } from '@/stores/control';
+
+import { UserCard } from './UserCard';
+
+export const UserCardHolder = () => {
+  const [isOpen, setIsOpen] = useAtom(modalAtom.userCard.isOpen);
+  const [user] = useAtom(modalAtom.userCard.user);
+  const [children] = useAtom(modalAtom.userCard.children);
+  // ここで if (!user) { return null; } としてしまうと,
+  // モーダルの初回表示時に出現アニメーションが効かない
+  return (
+    <Modal closeModal={() => setIsOpen(false)} isOpen={isOpen}>
+      {user && <UserCard id={user.id}>{children}</UserCard>}
+    </Modal>
+  );
+};

--- a/frontend/src/features/User/UserView.tsx
+++ b/frontend/src/features/User/UserView.tsx
@@ -45,14 +45,6 @@ const ActualView = ({ user }: ActualViewProps) => {
         {isBlocking && <Icons.User.Block className="h-6 w-6 shrink-0 grow-0" />}
       </FTH1>
       <div className="flex flex-col gap-2">
-        <FTH4>id</FTH4>
-        <div className="p-2">{user.id}</div>
-        <FTH4>name</FTH4>
-        <div className="p-2">{user.displayName}</div>
-        <FTH4>heartbeat time</FTH4>
-        <div className="p-2">
-          {user.time ? dayjs(user.time).format('MM/DD HH:mm:ss') : 'offline'}
-        </div>
         <FTH4>DM</FTH4>
         <div className="px-2 py-4">
           <DmCard user={user} />

--- a/frontend/src/features/User/components/HistoryCard.tsx
+++ b/frontend/src/features/User/components/HistoryCard.tsx
@@ -3,7 +3,29 @@ import dayjs from 'dayjs';
 import { UserAvatar } from '@/components/UserAvater';
 import { User } from '@/typedef';
 
-import { MatchResult } from '../types/MatchResult';
+import { MatchResult, MatchType } from '../types/MatchResult';
+
+const MatchTypeLabel = ({ matchType }: { matchType: MatchType }) => {
+  return (
+    <div className="border-[1px] border-solid border-white">{matchType}</div>
+  );
+};
+
+const OutcomeLabel = ({
+  matchResult,
+  user,
+}: {
+  matchResult: MatchResult;
+  user: User;
+}) => {
+  const isWinner =
+    matchResult.userScore1 > matchResult.userScore2 &&
+    matchResult.userID1 === user.id;
+  const r = isWinner
+    ? { className: 'text-red-400', text: 'WIN' }
+    : { className: 'text-blue-400', text: 'LOSE' };
+  return <div className={r.className}>{r.text}</div>;
+};
 
 type Props = {
   matchResult: MatchResult;
@@ -12,21 +34,20 @@ type Props = {
 };
 
 export const HistoryCard = ({ matchResult, opponent, user }: Props) => {
-  const isWinner =
-    matchResult.userScore1 > matchResult.userScore2 &&
-    matchResult.userID1 === user.id;
   return (
     <li className="flex items-center">
       <UserAvatar user={opponent} />
       <div className="overflow-hidden">
         <div className="mx-2 truncate text-lg">VS: {opponent.displayName}</div>
         <div className="flex">
-          <div className="mx-2 w-16 text-center	">{`${matchResult.userScore1} - ${matchResult.userScore2}`}</div>
-          <div className="mx-2 w-16 text-center">
-            {isWinner ? 'WIN' : 'LOSE'}
+          <div className="mx-2 shrink-0 grow-0 basis-16 text-center">{`${matchResult.userScore1} - ${matchResult.userScore2}`}</div>
+          <div className="shrink-0 grow-0 basis-16 text-center">
+            <OutcomeLabel matchResult={matchResult} user={user} />
           </div>
-          <div className="mx-2 w-16 text-center">{matchResult.matchType}</div>
-          <div className="mx-2 w-32 text-center">
+          <div className="shrink-0 grow-0 basis-20 text-center">
+            <MatchTypeLabel matchType={matchResult.matchType} />
+          </div>
+          <div className="mx-2 shrink grow text-center">
             {dayjs(matchResult.endAt).format('YYYY-MM-DD')}
           </div>
         </div>

--- a/frontend/src/features/User/components/HistoryCard.tsx
+++ b/frontend/src/features/User/components/HistoryCard.tsx
@@ -1,6 +1,8 @@
 import dayjs from 'dayjs';
 
+import { PopoverUserCard } from '@/components/PopoverUserCard';
 import { UserAvatar } from '@/components/UserAvater';
+import { useUserCard } from '@/stores/control';
 import { User } from '@/typedef';
 
 import { MatchResult, MatchType } from '../types/MatchResult';
@@ -34,12 +36,21 @@ type Props = {
 };
 
 export const HistoryCard = ({ matchResult, opponent, user }: Props) => {
+  const openCard = useUserCard();
+  const avatarButton = (
+    <UserAvatar user={opponent} onClick={() => openCard(opponent)} />
+  );
   return (
-    <li className="flex items-center">
-      <UserAvatar user={opponent} />
-      <div className="overflow-hidden">
-        <div className="mx-2 truncate text-lg">VS: {opponent.displayName}</div>
-        <div className="flex">
+    <li className="flex w-full flex-row items-center">
+      <div className="shrink-0 grow-0">
+        <PopoverUserCard button={avatarButton} />
+      </div>
+      <div className="flex shrink grow flex-col overflow-hidden">
+        <div className="mx-2 flex min-w-0 shrink-0 grow-0 flex-row text-lg">
+          <p>VS:</p>
+          <PopoverUserCard user={opponent} />
+        </div>
+        <div className="flex shrink-0 grow-0">
           <div className="mx-2 shrink-0 grow-0 basis-16 text-center">{`${matchResult.userScore1} - ${matchResult.userScore2}`}</div>
           <div className="shrink-0 grow-0 basis-16 text-center">
             <OutcomeLabel matchResult={matchResult} user={user} />

--- a/frontend/src/features/User/types/MatchResult.ts
+++ b/frontend/src/features/User/types/MatchResult.ts
@@ -1,9 +1,11 @@
+export type MatchType = 'RANK' | 'CASUAL' | 'PRIVATE';
+
 export type MatchResult = {
   startAt: Date;
   endAt: Date;
   id: string;
   matchStatus: 'PREPARING' | 'IN_PROGRESS' | 'DONE' | 'ERROR';
-  matchType: 'RANK' | 'CASUAL' | 'PRIVATE';
+  matchType: MatchType;
   userID1: number;
   userID2: number;
   userScore1: number;

--- a/frontend/src/stores/control.ts
+++ b/frontend/src/stores/control.ts
@@ -1,5 +1,23 @@
-import { atom } from 'jotai';
+import { atom, useAtom } from 'jotai';
 
-export const formAtom = {
+import { User } from '@/typedef';
+
+export const modalAtom = {
   isOpenCreateForm: atom(false),
+  userCard: {
+    isOpen: atom(false),
+    user: atom<User | null>(null),
+    children: atom<JSX.Element | null>(null),
+  },
 };
+
+export function useUserCard() {
+  const [, setIsOpen] = useAtom(modalAtom.userCard.isOpen);
+  const [, setUser] = useAtom(modalAtom.userCard.user);
+  const [, setChildren] = useAtom(modalAtom.userCard.children);
+  return function (user: User, children?: JSX.Element) {
+    setUser(user);
+    setChildren(children || null);
+    setIsOpen(true);
+  };
+}


### PR DESCRIPTION
### やったこと

- マッチタイプに白枠をつける
- 勝敗を赤青で色分け
- ユーザのアバター/名前クリックで`<UserCard>`を出す
  -  `<UserCard>`の出方をpopoverではなくmodalにしている