### PR TITLE
試合数0のユーザのStatsで勝率が`null%`になる

### DIFF
--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -97,9 +97,12 @@ export class PongService {
     ).length;
     const loseMatchCount = matchCount - winMatchCount;
 
-    const winRate = Math.floor(
-      ((winMatchCount / matchCount) * 100 * Math.pow(10, 2)) / Math.pow(10, 2)
-    );
+    const winRate = matchCount
+      ? Math.floor(
+          ((winMatchCount / matchCount) * 100 * Math.pow(10, 2)) /
+            Math.pow(10, 2)
+        )
+      : null;
 
     const userRankPoint = await this.prisma.userRankPoint
       .findUnique({

--- a/frontend/src/features/User/components/Stats.tsx
+++ b/frontend/src/features/User/components/Stats.tsx
@@ -6,6 +6,7 @@ import { FTH3 } from '@/components/FTBasicComponents';
 import { useManualErrorBoundary } from '@/components/ManualErrorBoundary';
 import { APIError } from '@/errors/APIError';
 import { useAPICallerWithCredential } from '@/hooks/useAPICaller';
+import { isfinite } from '@/utils';
 
 import { Stats } from '../types/MatchResult';
 
@@ -39,7 +40,9 @@ const RenderStats = ({
   return (
     <>
       <div className="mx-2">{`GameRecord: ${stats.winMatchCount} win - ${stats.loseMatchCount} lose`}</div>
-      <div className="mx-2">{`WinRate: ${stats.winRate}%`}</div>
+      <div className="mx-2">{`WinRate: ${
+        isfinite(stats.winRate) ? stats.winRate : '--'
+      }%`}</div>
       <div className="mx-2">{`RankPlace: ${ordinal(stats.rankPlace)}`}</div>
     </>
   );


### PR DESCRIPTION
-  (B) 勝率が計算不能なとき`null`を返す
  - 元々は`NaN`が返っており、それがJSON化によって`null`になっていた
-  (F) 勝率がfiniteでない時は`--`を表示する