### PR TITLE
matchを作成する部分の交通整理

### DIFF
--- a/backend/src/pong/game/online-match.ts
+++ b/backend/src/pong/game/online-match.ts
@@ -1,6 +1,5 @@
 import { MatchType } from '@prisma/client';
 import { Server } from 'socket.io';
-import { v4 as uuidv4 } from 'uuid';
 
 import {
   generateFullRoomName,
@@ -20,7 +19,7 @@ type FactoryProps = {
   matchType: MatchType;
   removeFn: (matchId: string) => void;
   postMatchStrategy: PostMatchStrategy;
-  matchId?: string;
+  matchId: string;
 };
 
 // このクラスは以下に対して責任を持つ
@@ -56,10 +55,6 @@ export class OnlineMatch {
     this.joinAsSpectator(userId2);
   }
 
-  static generateId() {
-    return uuidv4();
-  }
-
   static create({
     wsServer,
     userId1,
@@ -67,7 +62,7 @@ export class OnlineMatch {
     matchType,
     removeFn,
     postMatchStrategy,
-    matchId = uuidv4(),
+    matchId,
   }: FactoryProps) {
     return new OnlineMatch(
       wsServer,

--- a/backend/src/pong/game/online-match.ts
+++ b/backend/src/pong/game/online-match.ts
@@ -13,6 +13,16 @@ import { Match } from './match';
 import { PostMatchStrategy } from './PostMatchStrategy';
 import { MatchResult, PlayerInput } from './types/game-state';
 
+type FactoryProps = {
+  wsServer: Server;
+  userId1: number;
+  userId2: number;
+  matchType: MatchType;
+  removeFn: (matchId: string) => void;
+  postMatchStrategy: PostMatchStrategy;
+  matchId?: string;
+};
+
 // このクラスは以下に対して責任を持つ
 // - マッチの保持
 // - マッチのWSルームを作成
@@ -50,41 +60,22 @@ export class OnlineMatch {
     return uuidv4();
   }
 
-  static create(
-    wsServer: Server,
-    userId1: number,
-    userId2: number,
-    matchType: MatchType,
-    removeFromOngoingMatches: (matchId: string) => void,
-    postMatchStrategy: PostMatchStrategy
-  ) {
-    return new OnlineMatch(
-      wsServer,
-      uuidv4(),
-      userId1,
-      userId2,
-      matchType,
-      removeFromOngoingMatches,
-      postMatchStrategy
-    );
-  }
-
-  static createWithId(
-    wsServer: Server,
-    matchId: string,
-    userId1: number,
-    userId2: number,
-    matchType: MatchType,
-    removeFromOngoingMatches: (matchId: string) => void,
-    postMatchStrategy: PostMatchStrategy
-  ) {
+  static create({
+    wsServer,
+    userId1,
+    userId2,
+    matchType,
+    removeFn,
+    postMatchStrategy,
+    matchId = uuidv4(),
+  }: FactoryProps) {
     return new OnlineMatch(
       wsServer,
       matchId,
       userId1,
       userId2,
       matchType,
-      removeFromOngoingMatches,
+      removeFn,
       postMatchStrategy
     );
   }

--- a/backend/src/pong/game/pending-private-matches.ts
+++ b/backend/src/pong/game/pending-private-matches.ts
@@ -30,13 +30,10 @@ export class PendingPrivateMatches {
   createPrivateMatch(userId: number) {
     const matchId = OnlineMatch.generateId();
     this.pongService.createMatch({
-      id: matchId,
       matchType: MatchType.PRIVATE,
       matchStatus: MatchStatus.PREPARING,
       userId1: userId,
       userId2: undefined,
-      userScore1: 0,
-      userScore2: 0,
     });
     this.pendingMatches.set(userId, matchId);
     console.log(`createPrivateMatch: matchId(${matchId})`);

--- a/backend/src/pong/game/pending-private-matches.ts
+++ b/backend/src/pong/game/pending-private-matches.ts
@@ -71,15 +71,15 @@ export class PendingPrivateMatches {
     }
     this.drawOutMatchByMatchId(matchId);
     await this.pongService.setApplicantPlayer(matchId, userId);
-    const match = OnlineMatch.createWithId(
-      this.wsServer,
-      matchId,
-      matchOwnerId,
-      userId,
-      MatchType.PRIVATE,
-      (matchId: string) => this.ongoingMatches.removeMatch(matchId),
-      this.postMatchStrategy
-    );
+    const match = OnlineMatch.create({
+      wsServer: this.wsServer,
+      matchId: matchId,
+      userId1: matchOwnerId,
+      userId2: userId,
+      matchType: MatchType.PRIVATE,
+      removeFn: (matchId: string) => this.ongoingMatches.removeMatch(matchId),
+      postMatchStrategy: this.postMatchStrategy,
+    });
     this.ongoingMatches.appendMatch(match);
     sendResultRoom(
       this.wsServer,

--- a/backend/src/pong/game/pending-private-matches.ts
+++ b/backend/src/pong/game/pending-private-matches.ts
@@ -27,9 +27,8 @@ export class PendingPrivateMatches {
     this.pendingMatches = new Map<number, string>();
   }
 
-  createPrivateMatch(userId: number) {
-    const matchId = OnlineMatch.generateId();
-    this.pongService.createMatch({
+  async createPrivateMatch(userId: number) {
+    const { id: matchId } = await this.pongService.createMatch({
       matchType: MatchType.PRIVATE,
       matchStatus: MatchStatus.PREPARING,
       userId1: userId,

--- a/backend/src/pong/game/waiting-queue.ts
+++ b/backend/src/pong/game/waiting-queue.ts
@@ -89,22 +89,23 @@ export class WaitingQueue {
   }
 
   private async createMatch(userId1: number, userId2: number) {
+    const { id: matchId } = await this.pongService.createMatch({
+      matchType: this.matchType,
+      matchStatus: MatchStatus.PREPARING,
+      userId1,
+      userId2,
+    });
     const match = OnlineMatch.create({
       wsServer: this.wsServer,
-      userId1: userId1,
-      userId2: userId2,
+      userId1,
+      userId2,
       matchType: this.matchType,
       removeFn: (matchId: string) => this.ongoingMatches.removeMatch(matchId),
       postMatchStrategy: this.postMatchStrategy,
+      matchId,
     });
+
     this.ongoingMatches.appendMatch(match);
-    await this.pongService.createMatch({
-      matchType: match.matchType,
-      matchStatus: MatchStatus.PREPARING,
-      userId1: match.playerId1,
-      userId2: match.playerId2,
-    });
-    const matchId = match.matchId;
     usersLeave(
       this.wsServer,
       userId1,

--- a/backend/src/pong/game/waiting-queue.ts
+++ b/backend/src/pong/game/waiting-queue.ts
@@ -89,14 +89,14 @@ export class WaitingQueue {
   }
 
   private async createMatch(userId1: number, userId2: number) {
-    const match = OnlineMatch.create(
-      this.wsServer,
-      userId1,
-      userId2,
-      this.matchType,
-      (matchId: string) => this.ongoingMatches.removeMatch(matchId),
-      this.postMatchStrategy
-    );
+    const match = OnlineMatch.create({
+      wsServer: this.wsServer,
+      userId1: userId1,
+      userId2: userId2,
+      matchType: this.matchType,
+      removeFn: (matchId: string) => this.ongoingMatches.removeMatch(matchId),
+      postMatchStrategy: this.postMatchStrategy,
+    });
     this.ongoingMatches.appendMatch(match);
     await this.pongService.createMatch({
       id: match.matchId,

--- a/backend/src/pong/game/waiting-queue.ts
+++ b/backend/src/pong/game/waiting-queue.ts
@@ -99,13 +99,10 @@ export class WaitingQueue {
     });
     this.ongoingMatches.appendMatch(match);
     await this.pongService.createMatch({
-      id: match.matchId,
       matchType: match.matchType,
       matchStatus: MatchStatus.PREPARING,
       userId1: match.playerId1,
       userId2: match.playerId2,
-      userScore1: match.playerScore1,
-      userScore2: match.playerScore2,
     });
     const matchId = match.matchId;
     usersLeave(

--- a/backend/src/pong/pong.gateway.ts
+++ b/backend/src/pong/pong.gateway.ts
@@ -106,7 +106,7 @@ export class PongGateway {
       return;
     }
 
-    this.pendingPrivateMatches.createPrivateMatch(user.id);
+    await this.pendingPrivateMatches.createPrivateMatch(user.id);
   }
 
   // 募集中のプライベートに参加する

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -1,5 +1,6 @@
 import { HttpException, Injectable } from '@nestjs/common';
 import { MatchStatus, MatchType, UserSlotNumber } from '@prisma/client';
+import { v4 as uuidv4 } from 'uuid';
 
 import { UsersService } from 'src/users/users.service';
 import { WsServerGateway } from 'src/ws-server/ws-server.gateway';
@@ -9,13 +10,10 @@ import { compact } from '../utils';
 import { OnlineMatch } from './game/online-match';
 
 type CreateMatchDTO = {
-  id: string;
   matchType: MatchType;
   matchStatus: MatchStatus;
-  userId1?: number;
+  userId1: number;
   userId2?: number;
-  userScore1: number;
-  userScore2: number;
 };
 
 @Injectable()
@@ -139,13 +137,13 @@ export class PongService {
   async createMatch(match: CreateMatchDTO) {
     const result = await this.prisma.match.create({
       data: {
-        id: match.id,
+        id: uuidv4(),
         matchType: match.matchType,
         matchStatus: MatchStatus.PREPARING,
-        userId1: match.userId1 ? match.userId1 : 0,
-        userScore1: match.userScore1,
-        userId2: match.userId2 ? match.userId2 : 0,
-        userScore2: match.userScore1,
+        userId1: match.userId1,
+        userScore1: 0,
+        userId2: match.userId2 ?? 0,
+        userScore2: 0,
         startAt: new Date(),
 
         // TODO: Configを実装したらベタ書きを辞める

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -176,6 +176,8 @@ export class PongService {
       [result.userId1, result.userId2].filter((id) => !!id),
       result.id
     );
+
+    return result;
   }
 
   // プライベートマッチの参加者側(userId2)をセットする


### PR DESCRIPTION
#283 もついでに解決した

config作成処理をやってると、onlinematchを作ってからレコードを作る流れだと困るので順番を入れ替えた。
uuidでIDを振る処理を、先に行い、OnlineMatchを作成する時は、レコードが存在していることを前提として動く

online-matchを作るためにconfigが必要なので、レコードを先に作ってconfigをデータベースに用意する