### PR TITLE
284 カスタムマッチのルール変更された状態でゲームできるようにする

### DIFF
--- a/backend/src/pong/dto/pong-private-match-create.dto.ts
+++ b/backend/src/pong/dto/pong-private-match-create.dto.ts
@@ -1,3 +1,5 @@
 export type PongPrivateMatchCreateDTO = {
   roomId: string;
+  speed: number;
+  maxScore: number;
 };

--- a/backend/src/pong/game/match.ts
+++ b/backend/src/pong/game/match.ts
@@ -27,7 +27,7 @@ export class Match {
   static readonly barRightX = Match.fieldWidth * 0.9;
   static readonly barDy = 10;
   //rule
-  static readonly maxScore = 15;
+  static readonly defaultConfig = { maxScore: 15, speed: 100 };
   static readonly kickoffMaxAngle = 60; // in degree
 
   static readonly sideIndex = {
@@ -38,8 +38,16 @@ export class Match {
   ball: Ball;
   players: [Player, Player];
   winner: PongWinner;
+  maxScore: number;
+  speed: number;
 
-  constructor(playerId1: number, playerId2: number) {
+  constructor(
+    playerId1: number,
+    playerId2: number,
+    config: { maxScore: number; speed: number } = Match.defaultConfig
+  ) {
+    this.maxScore = config.maxScore;
+    this.speed = config.speed;
     this.winner = 'none';
     this.ball = this.regenerateBall();
     this.players = [
@@ -125,7 +133,7 @@ export class Match {
   updateScore = (side: PlayerSide) => {
     const index = Match.sideIndex[side];
     this.players[index].score++;
-    if (this.players[index].score >= Match.maxScore) {
+    if (this.players[index].score >= this.maxScore) {
       this.winner = side;
     }
   };

--- a/backend/src/pong/game/match.ts
+++ b/backend/src/pong/game/match.ts
@@ -97,7 +97,10 @@ export class Match {
     const rad =
       (Math.random() * 2 - 1) * Match.kickoffMaxAngle * (Math.PI / 180);
     const position = { x: Match.fieldWidth / 2, y: Match.fieldHeight / 2 };
-    const velocity = { x: Math.cos(rad), y: Math.sin(rad) };
+    const velocity = {
+      x: (this.speed / 100) * Math.cos(rad),
+      y: (this.speed / 100) * Math.sin(rad),
+    };
     return {
       position,
       velocity,

--- a/backend/src/pong/game/online-match.ts
+++ b/backend/src/pong/game/online-match.ts
@@ -1,6 +1,5 @@
 import { MatchType } from '@prisma/client';
 import { Server } from 'socket.io';
-import { v4 as uuidv4 } from 'uuid';
 
 import {
   generateFullRoomName,
@@ -20,7 +19,7 @@ type FactoryProps = {
   matchType: MatchType;
   removeFn: (matchId: string) => void;
   postMatchStrategy: PostMatchStrategy;
-  matchId?: string;
+  matchId: string;
 };
 
 // このクラスは以下に対して責任を持つ
@@ -56,10 +55,6 @@ export class OnlineMatch {
     this.joinAsSpectator(userId2);
   }
 
-  static generateId() {
-    return uuidv4();
-  }
-
   static create({
     wsServer,
     userId1,
@@ -67,7 +62,7 @@ export class OnlineMatch {
     matchType,
     removeFn,
     postMatchStrategy,
-    matchId = uuidv4(),
+    matchId,
   }: FactoryProps) {
     return new OnlineMatch(
       wsServer,

--- a/backend/src/pong/game/online-match.ts
+++ b/backend/src/pong/game/online-match.ts
@@ -13,6 +13,16 @@ import { Match } from './match';
 import { PostMatchStrategy } from './PostMatchStrategy';
 import { MatchResult, PlayerInput } from './types/game-state';
 
+type FactoryProps = {
+  wsServer: Server;
+  userId1: number;
+  userId2: number;
+  matchType: MatchType;
+  removeFn: (matchId: string) => void;
+  postMatchStrategy: PostMatchStrategy;
+  matchId?: string;
+};
+
 // このクラスは以下に対して責任を持つ
 // - マッチの保持
 // - マッチのWSルームを作成
@@ -50,41 +60,22 @@ export class OnlineMatch {
     return uuidv4();
   }
 
-  static create(
-    wsServer: Server,
-    userId1: number,
-    userId2: number,
-    matchType: MatchType,
-    removeFromOngoingMatches: (matchId: string) => void,
-    postMatchStrategy: PostMatchStrategy
-  ) {
-    return new OnlineMatch(
-      wsServer,
-      uuidv4(),
-      userId1,
-      userId2,
-      matchType,
-      removeFromOngoingMatches,
-      postMatchStrategy
-    );
-  }
-
-  static createWithId(
-    wsServer: Server,
-    matchId: string,
-    userId1: number,
-    userId2: number,
-    matchType: MatchType,
-    removeFromOngoingMatches: (matchId: string) => void,
-    postMatchStrategy: PostMatchStrategy
-  ) {
+  static create({
+    wsServer,
+    userId1,
+    userId2,
+    matchType,
+    removeFn,
+    postMatchStrategy,
+    matchId = uuidv4(),
+  }: FactoryProps) {
     return new OnlineMatch(
       wsServer,
       matchId,
       userId1,
       userId2,
       matchType,
-      removeFromOngoingMatches,
+      removeFn,
       postMatchStrategy
     );
   }

--- a/backend/src/pong/game/online-match.ts
+++ b/backend/src/pong/game/online-match.ts
@@ -20,6 +20,7 @@ type FactoryProps = {
   removeFn: (matchId: string) => void;
   postMatchStrategy: PostMatchStrategy;
   matchId: string;
+  config?: { maxScore: number; speed: number };
 };
 
 // このクラスは以下に対して責任を持つ
@@ -42,6 +43,7 @@ export class OnlineMatch {
     userId1: number,
     userId2: number,
     matchType: MatchType,
+    match: Match,
     private readonly removeFromOngoingMatches: (matchId: string) => void,
     private readonly postMatchStrategy: PostMatchStrategy
   ) {
@@ -50,7 +52,7 @@ export class OnlineMatch {
     this.Id = matchId;
     this.roomName = generateFullRoomName({ matchId: this.Id });
     this.matchType = matchType;
-    this.match = new Match(userId1, userId2);
+    this.match = match;
     this.joinAsSpectator(userId1);
     this.joinAsSpectator(userId2);
   }
@@ -63,6 +65,7 @@ export class OnlineMatch {
     removeFn,
     postMatchStrategy,
     matchId,
+    config,
   }: FactoryProps) {
     return new OnlineMatch(
       wsServer,
@@ -70,6 +73,7 @@ export class OnlineMatch {
       userId1,
       userId2,
       matchType,
+      new Match(userId1, userId2, config),
       removeFn,
       postMatchStrategy
     );

--- a/backend/src/pong/game/pending-private-matches.ts
+++ b/backend/src/pong/game/pending-private-matches.ts
@@ -30,13 +30,10 @@ export class PendingPrivateMatches {
   createPrivateMatch(userId: number) {
     const matchId = OnlineMatch.generateId();
     this.pongService.createMatch({
-      id: matchId,
       matchType: MatchType.PRIVATE,
       matchStatus: MatchStatus.PREPARING,
       userId1: userId,
       userId2: undefined,
-      userScore1: 0,
-      userScore2: 0,
     });
     this.pendingMatches.set(userId, matchId);
     console.log(`createPrivateMatch: matchId(${matchId})`);

--- a/backend/src/pong/game/pending-private-matches.ts
+++ b/backend/src/pong/game/pending-private-matches.ts
@@ -67,6 +67,8 @@ export class PendingPrivateMatches {
     }
     this.drawOutMatchByMatchId(matchId);
     await this.pongService.setApplicantPlayer(matchId, userId);
+
+    const config = await this.pongService.fetchMatchConfig(matchId);
     const match = OnlineMatch.create({
       wsServer: this.wsServer,
       matchId: matchId,
@@ -75,6 +77,7 @@ export class PendingPrivateMatches {
       matchType: MatchType.PRIVATE,
       removeFn: (matchId: string) => this.ongoingMatches.removeMatch(matchId),
       postMatchStrategy: this.postMatchStrategy,
+      config,
     });
     this.ongoingMatches.appendMatch(match);
     sendResultRoom(

--- a/backend/src/pong/game/pending-private-matches.ts
+++ b/backend/src/pong/game/pending-private-matches.ts
@@ -71,15 +71,15 @@ export class PendingPrivateMatches {
     }
     this.drawOutMatchByMatchId(matchId);
     await this.pongService.setApplicantPlayer(matchId, userId);
-    const match = OnlineMatch.createWithId(
-      this.wsServer,
-      matchId,
-      matchOwnerId,
-      userId,
-      MatchType.PRIVATE,
-      (matchId: string) => this.ongoingMatches.removeMatch(matchId),
-      this.postMatchStrategy
-    );
+    const match = OnlineMatch.create({
+      wsServer: this.wsServer,
+      matchId: matchId,
+      userId1: matchOwnerId,
+      userId2: userId,
+      matchType: MatchType.PRIVATE,
+      removeFn: (matchId: string) => this.ongoingMatches.removeMatch(matchId),
+      postMatchStrategy: this.postMatchStrategy,
+    });
     this.ongoingMatches.appendMatch(match);
     sendResultRoom(
       this.wsServer,

--- a/backend/src/pong/game/pending-private-matches.ts
+++ b/backend/src/pong/game/pending-private-matches.ts
@@ -27,9 +27,8 @@ export class PendingPrivateMatches {
     this.pendingMatches = new Map<number, string>();
   }
 
-  createPrivateMatch(userId: number) {
-    const matchId = OnlineMatch.generateId();
-    this.pongService.createMatch({
+  async createPrivateMatch(userId: number) {
+    const { id: matchId } = await this.pongService.createMatch({
       matchType: MatchType.PRIVATE,
       matchStatus: MatchStatus.PREPARING,
       userId1: userId,

--- a/backend/src/pong/game/pending-private-matches.ts
+++ b/backend/src/pong/game/pending-private-matches.ts
@@ -27,12 +27,14 @@ export class PendingPrivateMatches {
     this.pendingMatches = new Map<number, string>();
   }
 
-  async createPrivateMatch(userId: number) {
+  async createPrivateMatch(userId: number, maxScore: number, speed: number) {
     const { id: matchId } = await this.pongService.createMatch({
       matchType: MatchType.PRIVATE,
       matchStatus: MatchStatus.PREPARING,
       userId1: userId,
       userId2: undefined,
+      maxScore,
+      speed,
     });
     this.pendingMatches.set(userId, matchId);
     console.log(`createPrivateMatch: matchId(${matchId})`);

--- a/backend/src/pong/game/waiting-queue.ts
+++ b/backend/src/pong/game/waiting-queue.ts
@@ -89,22 +89,23 @@ export class WaitingQueue {
   }
 
   private async createMatch(userId1: number, userId2: number) {
+    const { id: matchId } = await this.pongService.createMatch({
+      matchType: this.matchType,
+      matchStatus: MatchStatus.PREPARING,
+      userId1,
+      userId2,
+    });
     const match = OnlineMatch.create({
       wsServer: this.wsServer,
-      userId1: userId1,
-      userId2: userId2,
+      userId1,
+      userId2,
       matchType: this.matchType,
       removeFn: (matchId: string) => this.ongoingMatches.removeMatch(matchId),
       postMatchStrategy: this.postMatchStrategy,
+      matchId,
     });
+
     this.ongoingMatches.appendMatch(match);
-    await this.pongService.createMatch({
-      matchType: match.matchType,
-      matchStatus: MatchStatus.PREPARING,
-      userId1: match.playerId1,
-      userId2: match.playerId2,
-    });
-    const matchId = match.matchId;
     usersLeave(
       this.wsServer,
       userId1,

--- a/backend/src/pong/game/waiting-queue.ts
+++ b/backend/src/pong/game/waiting-queue.ts
@@ -89,14 +89,14 @@ export class WaitingQueue {
   }
 
   private async createMatch(userId1: number, userId2: number) {
-    const match = OnlineMatch.create(
-      this.wsServer,
-      userId1,
-      userId2,
-      this.matchType,
-      (matchId: string) => this.ongoingMatches.removeMatch(matchId),
-      this.postMatchStrategy
-    );
+    const match = OnlineMatch.create({
+      wsServer: this.wsServer,
+      userId1: userId1,
+      userId2: userId2,
+      matchType: this.matchType,
+      removeFn: (matchId: string) => this.ongoingMatches.removeMatch(matchId),
+      postMatchStrategy: this.postMatchStrategy,
+    });
     this.ongoingMatches.appendMatch(match);
     await this.pongService.createMatch({
       id: match.matchId,

--- a/backend/src/pong/game/waiting-queue.ts
+++ b/backend/src/pong/game/waiting-queue.ts
@@ -99,13 +99,10 @@ export class WaitingQueue {
     });
     this.ongoingMatches.appendMatch(match);
     await this.pongService.createMatch({
-      id: match.matchId,
       matchType: match.matchType,
       matchStatus: MatchStatus.PREPARING,
       userId1: match.playerId1,
       userId2: match.playerId2,
-      userScore1: match.playerScore1,
-      userScore2: match.playerScore2,
     });
     const matchId = match.matchId;
     usersLeave(

--- a/backend/src/pong/pong.gateway.ts
+++ b/backend/src/pong/pong.gateway.ts
@@ -105,14 +105,11 @@ export class PongGateway {
       // - OngoingMatches
       return;
     }
-    //TODO: dataからこの部分を作る
-    const maxScore = 15;
-    const speed = 100;
 
     await this.pendingPrivateMatches.createPrivateMatch(
       user.id,
-      maxScore,
-      speed
+      data.maxScore,
+      data.speed
     );
   }
 

--- a/backend/src/pong/pong.gateway.ts
+++ b/backend/src/pong/pong.gateway.ts
@@ -106,7 +106,7 @@ export class PongGateway {
       return;
     }
 
-    this.pendingPrivateMatches.createPrivateMatch(user.id);
+    await this.pendingPrivateMatches.createPrivateMatch(user.id);
   }
 
   // 募集中のプライベートに参加する

--- a/backend/src/pong/pong.gateway.ts
+++ b/backend/src/pong/pong.gateway.ts
@@ -105,8 +105,15 @@ export class PongGateway {
       // - OngoingMatches
       return;
     }
+    //TODO: dataからこの部分を作る
+    const maxScore = 15;
+    const speed = 100;
 
-    await this.pendingPrivateMatches.createPrivateMatch(user.id);
+    await this.pendingPrivateMatches.createPrivateMatch(
+      user.id,
+      maxScore,
+      speed
+    );
   }
 
   // 募集中のプライベートに参加する

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -14,6 +14,8 @@ type CreateMatchDTO = {
   matchStatus: MatchStatus;
   userId1: number;
   userId2?: number;
+  speed?: number;
+  maxScore?: number;
 };
 
 @Injectable()
@@ -150,8 +152,8 @@ export class PongService {
         // TODO: Configを非Nullableにする
         config: {
           create: {
-            maxScore: 15,
-            speed: 10,
+            maxScore: match.maxScore ?? 15,
+            speed: match.speed ?? 100,
           },
         },
         matchUserRelation: {

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -1,5 +1,6 @@
 import { HttpException, Injectable } from '@nestjs/common';
 import { MatchStatus, MatchType, UserSlotNumber } from '@prisma/client';
+import { v4 as uuidv4 } from 'uuid';
 
 import { UsersService } from 'src/users/users.service';
 import { WsServerGateway } from 'src/ws-server/ws-server.gateway';
@@ -9,13 +10,10 @@ import { compact } from '../utils';
 import { OnlineMatch } from './game/online-match';
 
 type CreateMatchDTO = {
-  id: string;
   matchType: MatchType;
   matchStatus: MatchStatus;
-  userId1?: number;
+  userId1: number;
   userId2?: number;
-  userScore1: number;
-  userScore2: number;
 };
 
 @Injectable()
@@ -139,13 +137,13 @@ export class PongService {
   async createMatch(match: CreateMatchDTO) {
     const result = await this.prisma.match.create({
       data: {
-        id: match.id,
+        id: uuidv4(),
         matchType: match.matchType,
         matchStatus: MatchStatus.PREPARING,
-        userId1: match.userId1 ? match.userId1 : 0,
-        userScore1: match.userScore1,
-        userId2: match.userId2 ? match.userId2 : 0,
-        userScore2: match.userScore1,
+        userId1: match.userId1,
+        userScore1: 0,
+        userId2: match.userId2 ?? 0,
+        userScore2: 0,
         startAt: new Date(),
 
         // TODO: Configを実装したらベタ書きを辞める

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -176,6 +176,8 @@ export class PongService {
       [result.userId1, result.userId2].filter((id) => !!id),
       result.id
     );
+
+    return result;
   }
 
   // プライベートマッチの参加者側(userId2)をセットする

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -7,6 +7,7 @@ import { WsServerGateway } from 'src/ws-server/ws-server.gateway';
 
 import { PrismaService } from '../prisma/prisma.service';
 import { compact } from '../utils';
+import { Match } from './game/match';
 import { OnlineMatch } from './game/online-match';
 
 type CreateMatchDTO = {
@@ -152,8 +153,8 @@ export class PongService {
         // TODO: Configを非Nullableにする
         config: {
           create: {
-            maxScore: match.maxScore ?? 15,
-            speed: match.speed ?? 100,
+            maxScore: match.maxScore ?? Match.defaultConfig.maxScore,
+            speed: match.speed ?? Match.defaultConfig.speed,
           },
         },
         matchUserRelation: {

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -364,4 +364,12 @@ export class PongService {
         .then((u) => this.wsServer.pulse(u.user));
     });
   }
+
+  async fetchMatchConfig(matchId: string) {
+    const res = await this.prisma.matchConfig.findUnique({
+      where: { matchId: matchId },
+    });
+
+    return res ?? undefined;
+  }
 }

--- a/frontend/src/features/Chat/command.ts
+++ b/frontend/src/features/Chat/command.ts
@@ -97,6 +97,8 @@ export function makeCommand(
       console.log('[pong.private_match.create]', roomId);
       const data = {
         roomId,
+        speed: 100,
+        maxScore: 15,
       };
       mySocket.emit('pong.private_match.create', data);
     },

--- a/frontend/src/features/Pong/components/TopPage.tsx
+++ b/frontend/src/features/Pong/components/TopPage.tsx
@@ -41,7 +41,7 @@ export const PongTopPage = (props: { mySocket: ReturnType<typeof io> }) => {
     if (isWaiting) {
       return;
     }
-    mySocket.emit('pong.private_match.create');
+    mySocket.emit('pong.private_match.create', { maxScore: 15, speed: 100 });
   };
 
   // TODO: プライベートマッチデバッグ用。後で消す。


### PR DESCRIPTION
#290 に依存している

## やったこと
- `createPrivateMatch`の引数にコンフィグの値を渡せば、設定が変更できるようになった
- Matchにデフォルトのコンフィグを用意し、コンストラクタにconfigが渡らなければ、デフォルトの設定でmatchが作成される
- privateMatchを作るときは、onlineMatchを作るタイミングでmatchIdからconfigを取得し、matchを作成するときに渡す
- configのイメージ
  - maxScoreはデフォルトが15、1~100くらいまで可変するイメージ
  - speedはデフォルトのが100、50~100くらいまで可変し、ボールの移動に倍率でかける（最大1.5倍速）

## やってないこと
- speedの倍率をゲームに適用する部分
  - MaxScoreは適用されるようになっている