### PR TITLE
マッチングメッセージ

### DIFF
--- a/backend/prisma/migrations/20221222080327_/migration.sql
+++ b/backend/prisma/migrations/20221222080327_/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[matchId]` on the table `ChatMessage` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[messageId]` on the table `Match` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "ChatMessage" ADD COLUMN     "matchId" TEXT;
+
+-- AlterTable
+ALTER TABLE "Match" ADD COLUMN     "messageId" INTEGER;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChatMessage_matchId_key" ON "ChatMessage"("matchId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Match_messageId_key" ON "Match"("messageId");
+
+-- AddForeignKey
+ALTER TABLE "ChatMessage" ADD CONSTRAINT "ChatMessage_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "Match"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -129,6 +129,8 @@ model ChatMessage {
   content         String
   messageType     String?
   subpayload      Json?
+  match           Match?   @relation(name: "matchingMessage", fields: [matchId], references: [id])
+  matchId         String?  @unique
 }
 
 // ユーザーのランクポイント
@@ -162,6 +164,8 @@ model Match {
   endAt             DateTime? // 試合終了日時
   matchUserRelation MatchUserRelation[]
   config            MatchConfig?
+  message           ChatMessage?        @relation(name: "matchingMessage")
+  messageId         Int?                @unique
 }
 
 enum MatchType {

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -7,10 +7,7 @@ import * as Utils from 'src/utils';
 import { CreateSayDto } from './dto/create-say.dto';
 import { OperationSystemSayDto } from 'src/chatrooms/dto/operation-system-say.dto';
 
-import {
-  ChatroomsService,
-  RecordSpecifier,
-} from '../chatrooms/chatrooms.service';
+import { ChatroomsService } from '../chatrooms/chatrooms.service';
 import { UsersService } from '../users/users.service';
 
 export type SubPayload = {
@@ -43,19 +40,6 @@ export class ChatService {
       messageType: data.messageType,
       subpayload: data.subpayload,
       matchId: data.matchId,
-    });
-  }
-
-  async updateMatchingMessage(
-    specifier: RecordSpecifier,
-    matchId: string | null,
-    subpayload: SubPayload,
-    secondaryUserId?: number
-  ) {
-    return this.chatRoomService.updateMessageByMatchId(specifier, {
-      matchId,
-      secondaryUserId,
-      subpayload,
     });
   }
 

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -33,6 +33,7 @@ export class ChatService {
       secondaryUserId: data.secondaryId,
       messageType: data.messageType,
       subpayload: data.subpayload,
+      matchId: data.matchId,
     });
   }
 

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -37,6 +37,17 @@ export class ChatService {
     });
   }
 
+  async updateMatchingMessage(
+    matchId: string,
+    status: 'PR_START' | 'PR_CANCEL' | 'PR_RESULT' | 'PR_ERROR',
+    secondaryUserId?: number
+  ) {
+    return this.chatRoomService.updateMessageByMatchId(matchId, {
+      secondaryUserId,
+      subpayload: { status },
+    });
+  }
+
   async getDisplayName(userId: number | null) {
     if (!userId) {
       throw new WsException('failed to get displayName');

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -7,8 +7,17 @@ import * as Utils from 'src/utils';
 import { CreateSayDto } from './dto/create-say.dto';
 import { OperationSystemSayDto } from 'src/chatrooms/dto/operation-system-say.dto';
 
-import { ChatroomsService } from '../chatrooms/chatrooms.service';
+import {
+  ChatroomsService,
+  RecordSpecifier,
+} from '../chatrooms/chatrooms.service';
 import { UsersService } from '../users/users.service';
+
+export type SubPayload = {
+  status: 'PR_OPEN' | 'PR_CANCEL' | 'PR_START' | 'PR_RESULT' | 'PR_ERROR';
+  userScore1?: number;
+  userScore2?: number;
+};
 
 @Injectable()
 export class ChatService {
@@ -38,13 +47,15 @@ export class ChatService {
   }
 
   async updateMatchingMessage(
-    matchId: string,
-    status: 'PR_START' | 'PR_CANCEL' | 'PR_RESULT' | 'PR_ERROR',
+    specifier: RecordSpecifier,
+    matchId: string | null,
+    subpayload: SubPayload,
     secondaryUserId?: number
   ) {
-    return this.chatRoomService.updateMessageByMatchId(matchId, {
+    return this.chatRoomService.updateMessageByMatchId(specifier, {
+      matchId,
       secondaryUserId,
-      subpayload: { status },
+      subpayload,
     });
   }
 

--- a/backend/src/chatrooms/chatrooms.service.ts
+++ b/backend/src/chatrooms/chatrooms.service.ts
@@ -12,6 +12,7 @@ import { GetChatroomsDto } from './dto/get-chatrooms.dto';
 import { GetMessagesDto } from './dto/get-messages.dto';
 import { PostMessageDto } from './dto/post-message.dto';
 import { RoomMemberDto } from './dto/room-member.dto';
+import { UpdateMessageDto } from './dto/update-message.dto';
 import { UpdateRoomDto } from './dto/update-room.dto';
 
 import { PrismaService } from '../prisma/prisma.service';
@@ -388,6 +389,15 @@ export class ChatroomsService {
   postMessage(data: PostMessageDto) {
     // TODO: userがmemberか確認する。
     return this.prisma.chatMessage.create({ data });
+  }
+
+  updateMessageByMatchId(matchId: string, data: UpdateMessageDto) {
+    return this.prisma.chatMessage.update({
+      where: {
+        matchId,
+      },
+      data,
+    });
   }
 
   /**

--- a/backend/src/chatrooms/chatrooms.service.ts
+++ b/backend/src/chatrooms/chatrooms.service.ts
@@ -26,6 +26,8 @@ const selectForUser = {
   isEnabledAvatar: true,
 };
 
+export type RecordSpecifier = { matchId: string } | { id: number };
+
 @Injectable()
 export class ChatroomsService {
   constructor(private prisma: PrismaService) {}
@@ -357,6 +359,10 @@ export class ChatroomsService {
     return new ChatroomEntity(res);
   }
 
+  async getMessage(specifier: RecordSpecifier) {
+    return this.prisma.chatMessage.findUnique({ where: specifier });
+  }
+
   async getMessages(user: User, getMessageDto: GetMessagesDto) {
     const { roomId, take, cursor } = getMessageDto;
     if (!(await this.checkJoined(user, roomId))) {
@@ -391,11 +397,12 @@ export class ChatroomsService {
     return this.prisma.chatMessage.create({ data });
   }
 
-  updateMessageByMatchId(matchId: string, data: UpdateMessageDto) {
+  async updateMessageByMatchId(
+    specifier: RecordSpecifier,
+    data: UpdateMessageDto
+  ) {
     return this.prisma.chatMessage.update({
-      where: {
-        matchId,
-      },
+      where: specifier,
       data,
     });
   }

--- a/backend/src/chatrooms/dto/operation-system-say.dto.ts
+++ b/backend/src/chatrooms/dto/operation-system-say.dto.ts
@@ -34,4 +34,8 @@ export class OperationSystemSayDto {
   @IsOptional()
   @IsObject()
   subpayload?: any;
+
+  @IsOptional()
+  @IsString()
+  matchId?: string;
 }

--- a/backend/src/chatrooms/dto/post-message.dto.ts
+++ b/backend/src/chatrooms/dto/post-message.dto.ts
@@ -44,4 +44,8 @@ export class PostMessageDto {
   @IsOptional()
   @IsObject()
   subpayload?: any;
+
+  @IsOptional()
+  @IsString()
+  matchId?: any;
 }

--- a/backend/src/chatrooms/dto/update-message.dto.ts
+++ b/backend/src/chatrooms/dto/update-message.dto.ts
@@ -1,0 +1,7 @@
+import { PickType, PartialType } from '@nestjs/swagger';
+
+import { PostMessageDto } from './post-message.dto';
+
+export class UpdateMessageDto extends PartialType(
+  PickType(PostMessageDto, ['secondaryUserId', 'subpayload'] as const)
+) {}

--- a/backend/src/chatrooms/dto/update-message.dto.ts
+++ b/backend/src/chatrooms/dto/update-message.dto.ts
@@ -3,5 +3,9 @@ import { PickType, PartialType } from '@nestjs/swagger';
 import { PostMessageDto } from './post-message.dto';
 
 export class UpdateMessageDto extends PartialType(
-  PickType(PostMessageDto, ['secondaryUserId', 'subpayload'] as const)
+  PickType(PostMessageDto, [
+    'matchId',
+    'secondaryUserId',
+    'subpayload',
+  ] as const)
 ) {}

--- a/backend/src/chatrooms/entities/chat-message.entity.ts
+++ b/backend/src/chatrooms/entities/chat-message.entity.ts
@@ -17,15 +17,18 @@ export const MessageTypesWithTarget = [
   'PR_RESULT',
   'PR_ERROR',
 ] as const;
+export const MessageTypesMatching = ['PR_STATUS'] as const;
 export const MessageTypes = [
   ...MessageTypesSingle,
   ...MessageTypesWithPayload,
   ...MessageTypesWithTarget,
+  ...MessageTypesMatching,
 ] as const;
 
 export type MessageTypeSingle = typeof MessageTypesSingle[number];
 export type MessageTypeWithPayload = typeof MessageTypesWithPayload[number];
 export type MessageTypeWithTarget = typeof MessageTypesWithTarget[number];
+export type MessageTypeMatching = typeof MessageTypesMatching[number];
 export type MessageType = typeof MessageTypes[number];
 
 export class ChatMessageEntity {

--- a/backend/src/pong/game/PostMatchStrategy.ts
+++ b/backend/src/pong/game/PostMatchStrategy.ts
@@ -4,12 +4,17 @@ import { MatchType } from '@prisma/client';
 import { PongService } from '../pong.service';
 import { OnlineMatch } from './online-match';
 
+type onScored = (match: OnlineMatch) => void;
 type onDoneType = (match: OnlineMatch) => void;
 type onErrorType = (match: OnlineMatch) => void;
 
 @Injectable()
 export class PostMatchStrategy {
   constructor(private readonly pongService: PongService) {}
+
+  getOnScored(): onScored {
+    return (match: OnlineMatch) => this.onScored(match);
+  }
 
   getOnDone(matchType: MatchType): onDoneType {
     switch (matchType) {
@@ -31,6 +36,12 @@ export class PostMatchStrategy {
       case 'PRIVATE':
         return (match: OnlineMatch) => this.onErrorPrivateMatch(match);
     }
+  }
+
+  // onScored
+
+  private onScored(match: OnlineMatch): void {
+    this.pongService.updateMatchOnScored(match);
   }
 
   // onDone

--- a/backend/src/pong/game/match.ts
+++ b/backend/src/pong/game/match.ts
@@ -108,15 +108,20 @@ export class Match {
   };
 
   // ballとバーの位置を更新する
-  update = (): void => {
+  update = () => {
+    let scoreHasChanged = false;
+    let hasEnded = false;
     const roundWinner = this.roundWinnerExists();
     if (roundWinner === 'none') {
       this.updateBall();
     } else {
       this.updateScore(roundWinner);
+      hasEnded = this.winner !== 'none';
       this.ball = this.regenerateBall();
+      scoreHasChanged = true;
     }
     this.updateBar();
+    return { hasEnded, scoreHasChanged };
   };
 
   roundWinnerExists = (): PongWinner => {

--- a/backend/src/pong/pong.module.ts
+++ b/backend/src/pong/pong.module.ts
@@ -1,6 +1,7 @@
 import { forwardRef, Module } from '@nestjs/common';
 
 import { AuthModule } from 'src/auth/auth.module';
+import { ChatroomsModule } from 'src/chatrooms/chatrooms.module';
 import { UsersModule } from 'src/users/users.module';
 import { WsServerModule } from 'src/ws-server/ws-server.module';
 
@@ -26,6 +27,7 @@ import { PongService } from './pong.service';
     forwardRef(() => AuthModule),
     WsServerModule,
     forwardRef(() => UsersModule),
+    forwardRef(() => ChatroomsModule),
   ],
   exports: [PongService],
 })

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -231,7 +231,7 @@ export class PongService {
     await this.wsServer.updateMatchingMessage(
       { matchId },
       matchId,
-      { status: 'PR_START' },
+      { status: 'PR_START', userScore1: 0, userScore2: 0 },
       userId2
     );
   }

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -253,6 +253,7 @@ export class PongService {
           'PR_RESULT',
           loser
         );
+      await this.wsServer.updateMatchingMessage(match.matchId, 'PR_RESULT');
     }
   }
 
@@ -277,6 +278,7 @@ export class PongService {
           'PR_ERROR',
           user2
         );
+      await this.wsServer.updateMatchingMessage(match.matchId, 'PR_ERROR');
     }
   }
 
@@ -380,8 +382,10 @@ export class PongService {
     ]);
     if (match && match.matchType === 'PRIVATE' && match.relatedRoomId) {
       const user = await this.usersService.findOne(match.userId1);
-      if (user)
+      if (user) {
         await this.wsServer.systemSay(match.relatedRoomId, user, 'PR_CANCEL');
+        await this.wsServer.updateMatchingMessage(matchId, 'PR_CANCEL');
+      }
     }
   }
 

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -225,6 +225,7 @@ export class PongService {
         'PR_START',
         user2
       );
+    await this.wsServer.updateMatchingMessage(matchId, 'PR_START', userId2);
   }
 
   async updateMatchAsDone(match: OnlineMatch) {

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -184,7 +184,15 @@ export class PongService {
     );
     if (match.matchType === 'PRIVATE' && relatedRoomId) {
       const user = await this.usersService.findOne(match.userId1);
-      if (user) this.wsServer.systemSay(relatedRoomId, user, 'PR_OPEN');
+      if (user) {
+        this.wsServer.systemSay(relatedRoomId, user, 'PR_OPEN');
+        this.wsServer.systemSayMatching(
+          relatedRoomId,
+          user,
+          'PR_STATUS',
+          result.id
+        );
+      }
     }
     return result;
   }

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -236,6 +236,28 @@ export class PongService {
     );
   }
 
+  async updateMatchOnScored(match: OnlineMatch) {
+    const matchId = match.matchId;
+    const userScore1 = match.playerScores[0];
+    const userScore2 = match.playerScores[1];
+    await this.prisma.match.update({
+      where: {
+        id: matchId,
+      },
+      data: {
+        userScore1: match.playerScores[0],
+        userScore2: match.playerScores[1],
+      },
+    });
+    if (match.matchType === 'PRIVATE') {
+      await this.wsServer.updateMatchingMessage({ matchId }, matchId, {
+        status: 'PR_START',
+        userScore1,
+        userScore2,
+      });
+    }
+  }
+
   async updateMatchAsDone(match: OnlineMatch) {
     const matchId = match.matchId;
     const userScore1 = match.playerScores[0];

--- a/backend/src/ws-server/ws-server.gateway.ts
+++ b/backend/src/ws-server/ws-server.gateway.ts
@@ -4,6 +4,7 @@ import { Server, Socket } from 'socket.io';
 
 import { ChatService } from 'src/chat/chat.service';
 import {
+  MessageTypeMatching,
   MessageTypeSingle,
   MessageTypeWithPayload,
   MessageTypeWithTarget,
@@ -168,6 +169,23 @@ export class WsServerGateway {
       callerId: user.id,
       messageType,
       secondaryId: target.id,
+    });
+  }
+
+  async systemSayMatching(
+    roomId: number,
+    user: User,
+    messageType: MessageTypeMatching,
+    matchId: string
+  ) {
+    this.systemSayCore(roomId, user, {
+      roomId,
+      callerId: user.id,
+      messageType,
+      matchId,
+      subpayload: {
+        status: 'PR_OPEN',
+      },
     });
   }
 

--- a/backend/src/ws-server/ws-server.gateway.ts
+++ b/backend/src/ws-server/ws-server.gateway.ts
@@ -211,7 +211,6 @@ export class WsServerGateway {
       subpayload,
       secondaryUserId
     );
-    console.log('message', message);
     this.sendResults(
       'ft_update_message',
       {

--- a/backend/src/ws-server/ws-server.gateway.ts
+++ b/backend/src/ws-server/ws-server.gateway.ts
@@ -3,7 +3,10 @@ import { User } from '@prisma/client';
 import { Server, Socket } from 'socket.io';
 
 import { ChatService, SubPayload } from 'src/chat/chat.service';
-import { RecordSpecifier } from 'src/chatrooms/chatrooms.service';
+import {
+  ChatroomsService,
+  RecordSpecifier,
+} from 'src/chatrooms/chatrooms.service';
 import {
   MessageTypeMatching,
   MessageTypeSingle,
@@ -31,7 +34,10 @@ export class WsServerGateway {
   @WebSocketServer()
   server: Server;
 
-  constructor(private readonly chatService: ChatService) {}
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly chatRoomService: ChatroomsService
+  ) {}
 
   /**
    * 指定したユーザーIDのルームにjoinしているclientのsocketを取得する
@@ -205,11 +211,13 @@ export class WsServerGateway {
     subpayload: SubPayload,
     secondaryUserId?: number
   ) {
-    const message = await this.chatService.updateMatchingMessage(
+    const message = await this.chatRoomService.updateMessageByMatchId(
       specifier,
-      matchId,
-      subpayload,
-      secondaryUserId
+      {
+        matchId,
+        subpayload,
+        secondaryUserId,
+      }
     );
     this.sendResults(
       'ft_update_message',

--- a/backend/src/ws-server/ws-server.gateway.ts
+++ b/backend/src/ws-server/ws-server.gateway.ts
@@ -2,7 +2,8 @@ import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 import { User } from '@prisma/client';
 import { Server, Socket } from 'socket.io';
 
-import { ChatService } from 'src/chat/chat.service';
+import { ChatService, SubPayload } from 'src/chat/chat.service';
+import { RecordSpecifier } from 'src/chatrooms/chatrooms.service';
 import {
   MessageTypeMatching,
   MessageTypeSingle,
@@ -199,13 +200,15 @@ export class WsServerGateway {
   }
 
   async updateMatchingMessage(
-    matchId: string,
-    status: 'PR_START' | 'PR_CANCEL' | 'PR_RESULT' | 'PR_ERROR',
+    specifier: RecordSpecifier,
+    matchId: string | null,
+    subpayload: SubPayload,
     secondaryUserId?: number
   ) {
     const message = await this.chatService.updateMatchingMessage(
+      specifier,
       matchId,
-      status,
+      subpayload,
       secondaryUserId
     );
     console.log('message', message);

--- a/backend/src/ws-server/ws-server.module.ts
+++ b/backend/src/ws-server/ws-server.module.ts
@@ -1,12 +1,13 @@
 import { forwardRef, Module } from '@nestjs/common';
 
 import { ChatModule } from 'src/chat/chat.module';
+import { ChatroomsModule } from 'src/chatrooms/chatrooms.module';
 
 import { WsServerGateway } from './ws-server.gateway';
 
 @Module({
   providers: [WsServerGateway],
-  imports: [forwardRef(() => ChatModule)],
+  imports: [forwardRef(() => ChatModule), forwardRef(() => ChatroomsModule)],
   exports: [WsServerGateway],
 })
 export class WsServerModule {}

--- a/frontend/src/components/ChatMatchingMessageCard.tsx
+++ b/frontend/src/components/ChatMatchingMessageCard.tsx
@@ -1,15 +1,11 @@
-import * as dayjs from 'dayjs';
 import { useAtom } from 'jotai';
 
 import { makeCommand } from '@/features/Chat/command';
-import { InlineIcon } from '@/hocs/InlineIcon';
 import { useConfirmModal } from '@/hooks/useConfirmModal';
-import { Icons } from '@/icons';
 import { chatSocketAtom } from '@/stores/auth';
 import { useUserDataReadOnly } from '@/stores/store';
 import { dataAtom } from '@/stores/structure';
 import * as TD from '@/typedef';
-import { compact } from '@/utils';
 
 import { ChatMessageProp } from './ChatMessageCard';
 import { FTButton } from './FTBasicComponents';
@@ -47,7 +43,6 @@ export const ChatMatchingMessageCard = (props: ChatMessageProp) => {
   const [, confirmModal] = useConfirmModal();
   const [mySocket] = useAtom(chatSocketAtom);
   const matchId = props.message.matchId;
-  console.log('props.message', props.message);
   if (
     !mySocket ||
     !matchId ||

--- a/frontend/src/components/ChatMatchingMessageCard.tsx
+++ b/frontend/src/components/ChatMatchingMessageCard.tsx
@@ -3,25 +3,51 @@ import { useAtom } from 'jotai';
 import { makeCommand } from '@/features/Chat/command';
 import { useConfirmModal } from '@/hooks/useConfirmModal';
 import { chatSocketAtom } from '@/stores/auth';
+import { useUserCard } from '@/stores/control';
 import { useUserDataReadOnly } from '@/stores/store';
 import { dataAtom } from '@/stores/structure';
 import * as TD from '@/typedef';
 
+import { AdminOperationBar } from './ChatMemberCard';
 import { ChatMessageProp } from './ChatMessageCard';
 import { FTButton } from './FTBasicComponents';
+import { PopoverUserCard } from './PopoverUserCard';
 import { UserAvatar } from './UserAvater';
 
 type PlayerProp = {
   user?: TD.User;
+  popoverContent: JSX.Element;
 };
 
-const PlayerCard = ({ user }: PlayerProp) => {
+const PlayerCard = ({ user, popoverContent }: PlayerProp) => {
+  const oc = useUserCard();
+  const openCard = () => {
+    if (!user) {
+      return;
+    }
+    oc(user, popoverContent);
+  };
+  const AvatarContent = () => {
+    if (!user) {
+      return <UserAvatar user={user} />;
+    }
+    const avatarButton = <UserAvatar user={user} onClick={openCard} />;
+    return (
+      <PopoverUserCard button={avatarButton}>{popoverContent}</PopoverUserCard>
+    );
+  };
+  const nameContent = (() => {
+    if (!user) {
+      return <>対戦相手を募集中</>;
+    }
+    return <PopoverUserCard user={user}>{popoverContent}</PopoverUserCard>;
+  })();
   return (
-    <div className="flex w-48 shrink-0 grow-0 flex-col items-center">
-      <UserAvatar user={user} />
-      <p className="text-center text-xl">
-        {user?.displayName || '対戦相手を募集中'}
-      </p>
+    <div className="flex w-[120px] shrink-0 grow-0 flex-col items-center overflow-hidden">
+      <AvatarContent />
+      <div className="w-full overflow-hidden text-ellipsis whitespace-nowrap text-center text-xl">
+        {nameContent}
+      </div>
     </div>
   );
 };
@@ -60,7 +86,7 @@ export const ChatMatchingMessageCard = (props: ChatMessageProp) => {
   }
   return (
     <div
-      className="m-2 flex flex-row items-start border-2 border-solid px-2 py-1 text-sm  hover:bg-gray-800"
+      className="m-2 flex flex-row items-start overflow-hidden border-2 border-solid px-2 py-1 text-sm hover:bg-gray-800"
       key={props.message.id}
       id={props.id}
     >
@@ -88,12 +114,23 @@ export const ChatMatchingMessageCard = (props: ChatMessageProp) => {
           )}
         </div>
         <div className="flex flex-row items-center justify-center">
-          <PlayerCard user={user} />
+          <PlayerCard
+            user={user}
+            popoverContent={<AdminOperationBar {...props} />}
+          />
           <div className="shrink-0 grow-0">
-            <p className="text-5xl">VS</p>
+            <p className="p-1 text-5xl">VS</p>
           </div>
           <div className="shrink-0 grow-0">
-            <PlayerCard user={targetUser} />
+            <PlayerCard
+              user={targetUser}
+              popoverContent={
+                <AdminOperationBar
+                  {...props}
+                  member={props.members[targetUser.id]}
+                />
+              }
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/ChatMatchingMessageCard.tsx
+++ b/frontend/src/components/ChatMatchingMessageCard.tsx
@@ -81,8 +81,8 @@ const PlayerCard = ({ user, popoverContent }: PlayerProp) => {
 
 type SubPayload = {
   status: 'PR_OPEN' | 'PR_CANCEL' | 'PR_START' | 'PR_RESULT' | 'PR_ERROR';
-  userScore?: number;
-  secondaryUserScore?: number;
+  userScore1?: number;
+  userScore2?: number;
 };
 
 /**
@@ -140,9 +140,7 @@ export const ChatMatchingMessageCard = (props: ChatMessageProp) => {
     >
       <div className="flex w-full flex-col items-center">
         <div>
-          <span className="text-2xl font-bold">
-            [{status}] [{matchId}]
-          </span>
+          <span className="text-2xl font-bold">[{status}]</span>
           {isCancelable && (
             <FTButton
               onClick={async () => {

--- a/frontend/src/components/ChatMatchingMessageCard.tsx
+++ b/frontend/src/components/ChatMatchingMessageCard.tsx
@@ -1,0 +1,107 @@
+import * as dayjs from 'dayjs';
+import { useAtom } from 'jotai';
+
+import { makeCommand } from '@/features/Chat/command';
+import { InlineIcon } from '@/hocs/InlineIcon';
+import { useConfirmModal } from '@/hooks/useConfirmModal';
+import { Icons } from '@/icons';
+import { chatSocketAtom } from '@/stores/auth';
+import { useUserDataReadOnly } from '@/stores/store';
+import { dataAtom } from '@/stores/structure';
+import * as TD from '@/typedef';
+import { compact } from '@/utils';
+
+import { ChatMessageProp } from './ChatMessageCard';
+import { FTButton } from './FTBasicComponents';
+import { UserAvatar } from './UserAvater';
+
+type PlayerProp = {
+  user?: TD.User;
+};
+
+const PlayerCard = ({ user }: PlayerProp) => {
+  return (
+    <div className="flex w-48 shrink-0 grow-0 flex-col items-center">
+      <UserAvatar user={user} />
+      <p className="text-center text-xl">
+        {user?.displayName || '対戦相手を募集中'}
+      </p>
+    </div>
+  );
+};
+
+type SubPayload = {
+  status: 'PR_OPEN' | 'PR_CANCEL' | 'PR_START' | 'PR_RESULT' | 'PR_ERROR';
+  userScore?: number;
+  secondaryUserScore?: number;
+};
+
+/**
+ * システムメッセージを表示するコンポーネント
+ */
+export const ChatMatchingMessageCard = (props: ChatMessageProp) => {
+  const messageType = props.message.messageType;
+  const user = useUserDataReadOnly(props.userId);
+  const targetUser = useUserDataReadOnly(props.message.secondaryUserId || -1);
+  const [blockingUsers] = useAtom(dataAtom.blockingUsers);
+  const [, confirmModal] = useConfirmModal();
+  const [mySocket] = useAtom(chatSocketAtom);
+  const matchId = props.message.matchId;
+  console.log('props.message', props.message);
+  if (
+    !mySocket ||
+    !matchId ||
+    messageType !== 'PR_STATUS' ||
+    !props.message.subpayload
+  ) {
+    return null;
+  }
+  const command = makeCommand(mySocket, props.room.id);
+  const { status } = props.message.subpayload as SubPayload;
+  const isBlocked =
+    blockingUsers && blockingUsers.find((u) => u.id === props.message.userId);
+  if (!user || isBlocked) {
+    return null;
+  }
+  return (
+    <div
+      className="m-2 flex flex-row items-start border-2 border-solid px-2 py-1 text-sm  hover:bg-gray-800"
+      key={props.message.id}
+      id={props.id}
+    >
+      <div className="flex w-full flex-col items-center">
+        <div>
+          <span className="text-2xl font-bold">Private Match[{status}]</span>
+          {status === 'PR_OPEN' && (
+            <FTButton
+              onClick={async () => {
+                if (
+                  await confirmModal(
+                    'プライベートマッチの募集をキャンセルしますか？',
+                    {
+                      affirm: 'キャンセルする',
+                      denial: 'しない',
+                    }
+                  )
+                ) {
+                  command.pong_private_match_cancel(matchId);
+                }
+              }}
+            >
+              キャンセル
+            </FTButton>
+          )}
+        </div>
+        <div className="flex flex-row items-center justify-center">
+          <PlayerCard user={user} />
+          <div className="shrink-0 grow-0">
+            <p className="text-5xl">VS</p>
+          </div>
+          <div className="shrink-0 grow-0">
+            <PlayerCard user={targetUser} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/ChatMatchingMessageCard.tsx
+++ b/frontend/src/components/ChatMatchingMessageCard.tsx
@@ -164,26 +164,21 @@ export const ChatMatchingMessageCard = (props: ChatMessageProp) => {
       : 'none';
   const verdict2 =
     verdict1 !== 'none' ? (verdict1 === 'won' ? 'lose' : 'won') : 'none';
-  const opponentContent = (() => {
-    return (
-      <PlayerCard
-        user={targetUser}
-        popoverContent={
-          targetUser && (
-            <AdminOperationBar
-              {...props}
-              member={props.members[targetUser.id]}
-            />
-          )
-        }
-        userScore={userScore2}
-        side="right"
-        verdict={verdict2}
-        matchId={matchId}
-        isYours={isYours}
-      />
-    );
-  })();
+  const opponentContent = (() => (
+    <PlayerCard
+      user={targetUser}
+      popoverContent={
+        targetUser && (
+          <AdminOperationBar {...props} member={props.members[targetUser.id]} />
+        )
+      }
+      userScore={userScore2}
+      side="right"
+      verdict={verdict2}
+      matchId={matchId}
+      isYours={isYours}
+    />
+  ))();
 
   const isSpectatable = status === 'PR_START';
   const spectateClass = isSpectatable ? 'cursor-pointer' : '';

--- a/frontend/src/components/ChatMatchingMessageCard.tsx
+++ b/frontend/src/components/ChatMatchingMessageCard.tsx
@@ -183,7 +183,7 @@ export const ChatMatchingMessageCard = (props: ChatMessageProp) => {
   }
   const isYours = props.you?.userId === user.id;
   const verdict1 =
-    isfinite(userScore1) && isfinite(userScore2)
+    status === 'PR_RESULT' && isfinite(userScore1) && isfinite(userScore2)
       ? userScore1 > userScore2
         ? 'won'
         : 'lose'

--- a/frontend/src/components/ChatMessageCard.tsx
+++ b/frontend/src/components/ChatMessageCard.tsx
@@ -10,18 +10,23 @@ import { AdminOperationBar } from './ChatMemberCard';
 import { PopoverUserCard } from './PopoverUserCard';
 import { UserAvatar } from './UserAvater';
 
-/**
- * メッセージを表示するコンポーネント
- */
-export const ChatMessageCard = (props: {
+export type ChatMessageProp = {
   you: TD.ChatUserRelation | null;
   room: TD.ChatRoom;
   message: TD.ChatRoomMessage;
   userId: number;
   member?: TD.ChatUserRelation;
+  members: TD.UserRelationMap;
   memberOperations?: TD.MemberOperations;
   id: string;
-}) => {
+};
+
+export type ChatMessageCardComponent = (props: ChatMessageProp) => JSX.Element;
+
+/**
+ * メッセージを表示するコンポーネント
+ */
+export const ChatMessageCard = (props: ChatMessageProp) => {
   const user = useUserDataReadOnly(props.userId);
   const openCard = useUserCard();
   const [blockingUsers] = useAtom(dataAtom.blockingUsers);

--- a/frontend/src/components/ChatSystemMessageCard.tsx
+++ b/frontend/src/components/ChatSystemMessageCard.tsx
@@ -9,6 +9,7 @@ import * as TD from '@/typedef';
 import { compact } from '@/utils';
 
 import { AdminOperationBar } from './ChatMemberCard';
+import { ChatMessageProp } from './ChatMessageCard';
 import { PopoverUserCard } from './PopoverUserCard';
 
 type ContentProp = {
@@ -137,16 +138,7 @@ const Content = ({ message, PrimaryChild, SecondaryChild }: ContentProp) => {
 /**
  * システムメッセージを表示するコンポーネント
  */
-export const ChatSystemMessageCard = (props: {
-  you: TD.ChatUserRelation | null;
-  room: TD.ChatRoom;
-  message: TD.ChatRoomMessage;
-  userId: number;
-  member?: TD.ChatUserRelation;
-  members: TD.UserRelationMap;
-  memberOperations?: TD.MemberOperations;
-  id: string;
-}) => {
+export const ChatSystemMessageCard = (props: ChatMessageProp) => {
   const messageType = props.message.messageType;
   const user = useUserDataReadOnly(props.userId);
   const targetUser = useUserDataReadOnly(props.message.secondaryUserId || -1);

--- a/frontend/src/components/UserAvater.tsx
+++ b/frontend/src/components/UserAvater.tsx
@@ -1,7 +1,7 @@
 import * as TD from '@/typedef';
 
 type Props = {
-  user: {
+  user?: {
     id: number;
     isEnabledAvatar: boolean;
     avatarTime: number;
@@ -11,18 +11,29 @@ type Props = {
 };
 
 export const UserAvatar = ({ user, className, onClick }: Props) => {
-  return (
-    <img
-      src={
-        user.isEnabledAvatar
-          ? `http://localhost:3000/users/${user.id}/avatar?${user.avatarTime}`
-          : '/Kizaru.png'
-      }
-      alt="CurrentUserProfileImage"
-      className={`${className || 'm-3 h-14 w-14'} object-cover ${
-        onClick ? ' cursor-pointer' : ''
-      }`}
-      onClick={onClick}
-    />
-  );
+  if (user) {
+    return (
+      <img
+        src={
+          user.isEnabledAvatar
+            ? `http://localhost:3000/users/${user.id}/avatar?${user.avatarTime}`
+            : '/Kizaru.png'
+        }
+        alt="CurrentUserProfileImage"
+        className={`${className || 'm-3 h-14 w-14'} object-cover ${
+          onClick ? ' cursor-pointer' : ''
+        }`}
+        onClick={onClick}
+      />
+    );
+  } else {
+    return (
+      <div
+        className={`${className || 'm-3 h-14 w-14'} border-2 object-cover ${
+          onClick ? ' cursor-pointer' : ''
+        }`}
+        onClick={onClick}
+      />
+    );
+  }
 };

--- a/frontend/src/features/Chat/command.ts
+++ b/frontend/src/features/Chat/command.ts
@@ -129,5 +129,22 @@ export function makeCommand(
         });
       });
     },
+
+    pong_private_match_join: (matchId: string) => {
+      console.log('[pong.private_match.join]', matchId);
+      const data = {
+        matchId,
+      };
+      return new Promise<any>((res, rej) => {
+        mySocket.emit('pong.private_match.join', data, (result: any) => {
+          console.log('result', result);
+          if (result && result.status === 'accepted') {
+            res(result);
+            return;
+          }
+          rej(result);
+        });
+      });
+    },
   };
 }

--- a/frontend/src/features/Chat/command.ts
+++ b/frontend/src/features/Chat/command.ts
@@ -112,5 +112,22 @@ export function makeCommand(
         });
       });
     },
+
+    pong_private_match_cancel: (matchId: string) => {
+      console.log('[pong.private_match.leave]', matchId);
+      const data = {
+        matchId,
+      };
+      return new Promise<any>((res, rej) => {
+        mySocket.emit('pong.private_match.leave', data, (result: any) => {
+          console.log('result', result);
+          if (result && result.status === 'accepted') {
+            res(result);
+            return;
+          }
+          rej(result);
+        });
+      });
+    },
   };
 }

--- a/frontend/src/features/Chat/command.ts
+++ b/frontend/src/features/Chat/command.ts
@@ -103,7 +103,6 @@ export function makeCommand(
       };
       return new Promise<any>((res, rej) => {
         mySocket.emit('pong.private_match.create', data, (result: any) => {
-          console.log('result', result);
           if (result && result.status === 'accepted') {
             res(result);
             return;
@@ -120,7 +119,6 @@ export function makeCommand(
       };
       return new Promise<any>((res, rej) => {
         mySocket.emit('pong.private_match.leave', data, (result: any) => {
-          console.log('result', result);
           if (result && result.status === 'accepted') {
             res(result);
             return;
@@ -137,7 +135,6 @@ export function makeCommand(
       };
       return new Promise<any>((res, rej) => {
         mySocket.emit('pong.private_match.join', data, (result: any) => {
-          console.log('result', result);
           if (result && result.status === 'accepted') {
             res(result);
             return;

--- a/frontend/src/features/Chat/components/RoomView.tsx
+++ b/frontend/src/features/Chat/components/RoomView.tsx
@@ -3,6 +3,7 @@ import { useEffect, useId, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { io } from 'socket.io-client';
 
+import { ChatMatchingMessageCard } from '@/components/ChatMatchingMessageCard';
 import { ChatMemberCard } from '@/components/ChatMemberCard';
 import { ChatMessageCard } from '@/components/ChatMessageCard';
 import { ChatSystemMessageCard } from '@/components/ChatSystemMessageCard';
@@ -131,27 +132,23 @@ const MessagesList = (props: {
     get_room_members(props.room.id);
   }, [mySocket, props.room.id]);
 
+  const componentForMessage = (data: TD.ChatRoomMessage) => {
+    if (data.messageType === 'PR_STATUS') {
+      return ChatMatchingMessageCard;
+    }
+    if (data.messageType) {
+      return ChatSystemMessageCard;
+    }
+    return ChatMessageCard;
+  };
+  console.log('props.messages', props.messages);
   return (
     <div id={listId} className="h-full overflow-scroll">
       {props.messages.map((data: TD.ChatRoomMessage) => {
         const member = props.members[data.userId];
-        if (data.messageType) {
-          return (
-            <ChatSystemMessageCard
-              key={data.id}
-              id={messageCardId(data)}
-              message={data}
-              you={props.you}
-              room={props.room}
-              userId={data.userId}
-              member={member}
-              members={props.members}
-              memberOperations={props.memberOperations}
-            />
-          );
-        }
+        const Component = componentForMessage(data);
         return (
-          <ChatMessageCard
+          <Component
             key={data.id}
             id={messageCardId(data)}
             message={data}
@@ -159,6 +156,7 @@ const MessagesList = (props: {
             room={props.room}
             userId={data.userId}
             member={member}
+            members={props.members}
             memberOperations={props.memberOperations}
           />
         );

--- a/frontend/src/features/Chat/components/RoomView.tsx
+++ b/frontend/src/features/Chat/components/RoomView.tsx
@@ -141,7 +141,6 @@ const MessagesList = (props: {
     }
     return ChatMessageCard;
   };
-  console.log('props.messages', props.messages);
   return (
     <div id={listId} className="h-full overflow-scroll">
       {props.messages.map((data: TD.ChatRoomMessage) => {

--- a/frontend/src/features/Pong/components/TopPage.tsx
+++ b/frontend/src/features/Pong/components/TopPage.tsx
@@ -14,8 +14,6 @@ export const PongTopPage = (props: { mySocket: ReturnType<typeof io> }) => {
 
   const cancelWaiting = () => {
     mySocket.emit('pong.match_making.leave');
-    // TODO: プライベートマッチデバッグ用。後で消す。
-    mySocket.emit('pong.private_match.leave');
     setIsWaiting(false);
   };
 
@@ -24,36 +22,6 @@ export const PongTopPage = (props: { mySocket: ReturnType<typeof io> }) => {
       return;
     }
     mySocket.emit('pong.match_making.entry', { matchType: matchType });
-  };
-
-  // TODO: プライベートマッチデバッグ用。後で消す。
-  const [inputtedPrivateMatchId, setInputtedPrivateMatchId] = useState('');
-
-  // TODO: プライベートマッチデバッグ用。後で消す。
-  mySocket.on('pong.private_match.created', (data: { matchId: string }) => {
-    // デバッグようにクリップボードにコピーする
-    navigator.clipboard.writeText(data.matchId);
-    console.log(`created match: ${data.matchId}`);
-  });
-
-  // TODO: プライベートマッチデバッグ用。後で消す。
-  const createPrivateMatch = () => {
-    if (isWaiting) {
-      return;
-    }
-    mySocket.emit('pong.private_match.create', {
-      roomId: 2,
-      maxScore: 150,
-      speed: 1000,
-    });
-  };
-
-  // TODO: プライベートマッチデバッグ用。後で消す。
-  const joinPrivateMatch = (matchId: string) => {
-    console.log('pong.private_match.join ', matchId);
-    mySocket.emit('pong.private_match.join', {
-      matchId: matchId,
-    });
   };
 
   return (
@@ -83,33 +51,6 @@ export const PongTopPage = (props: { mySocket: ReturnType<typeof io> }) => {
             onClick={() => {
               setIsWaiting(true);
               startMatchMaking('RANK');
-            }}
-          />
-          <CommandCard
-            text="プライベートマッチを作成(デバッグ用)"
-            onClick={() => {
-              // TODO: このCommandCardはプライベートマッチのデバッグ用なので後で消す
-              setIsWaiting(true);
-              createPrivateMatch();
-            }}
-          />
-          <input
-            type={'text'}
-            value={inputtedPrivateMatchId}
-            onChange={(event) => {
-              console.log(
-                `privateMatch input form event value: ${event.target.value}`
-              );
-              setInputtedPrivateMatchId(event.target.value);
-            }}
-            className="text-black"
-          />
-          <CommandCard
-            text="プライベートマッチに参加(デバッグ用)"
-            onClick={() => {
-              // TODO: このCommandCardはプライベートマッチのデバッグ用なので後で消す
-              setIsWaiting(true);
-              joinPrivateMatch(inputtedPrivateMatchId);
             }}
           />
           <CommandCard

--- a/frontend/src/features/Socket/SocketHolder.tsx
+++ b/frontend/src/features/Socket/SocketHolder.tsx
@@ -334,6 +334,7 @@ export const SocketHolder = () => {
     listeners.push([
       'ft_update_message',
       (data: TD.MessageUpdateResult) => {
+        console.log('catch update_message', data);
         const { roomId, messageId, message } = data;
         messageUpdater.setOne(roomId, messageId, message);
       },

--- a/frontend/src/hooks/useConfirmModal.tsx
+++ b/frontend/src/hooks/useConfirmModal.tsx
@@ -59,7 +59,26 @@ export const useConfirmModal = () => {
   ) => {
     return confirm(body, { isDestructive: true, ...arg });
   };
-  return [confirm, confirmDestructive] as const;
+  const confirmAndExec =
+    (body: string, proc: () => any, arg: Omit<ConfirmArg, 'body'> = {}) =>
+    async () => {
+      if (await confirm(body, arg)) {
+        proc();
+      }
+    };
+  const confirmDestructiveAndExec =
+    (body: string, proc: () => any, arg: Omit<ConfirmArg, 'body'> = {}) =>
+    async () => {
+      if (await confirmDestructive(body, arg)) {
+        proc();
+      }
+    };
+  return [
+    confirm,
+    confirmDestructive,
+    confirmAndExec,
+    confirmDestructiveAndExec,
+  ] as const;
 };
 
 /**

--- a/frontend/src/icons.ts
+++ b/frontend/src/icons.ts
@@ -53,6 +53,7 @@ const User = {
 
 const Pong = {
   Game: Ri.RiPingPongLine,
+  Won: Fa.FaMedal,
 };
 
 export const Icons = {

--- a/frontend/src/stores/structure.ts
+++ b/frontend/src/stores/structure.ts
@@ -185,7 +185,7 @@ export const useUpdateJoiningRooms = () => {
 };
 
 export const useUpdateMessage = () => {
-  const [messages, setMessages] = useAtom(structureAtom.messagesInRoomAtom);
+  const [, setMessages] = useAtom(structureAtom.messagesInRoomAtom);
   const setOne = (
     roomId: number,
     messageId: number,
@@ -202,8 +202,7 @@ export const useUpdateMessage = () => {
       }
       const nms = [...ms];
       nms[i] = data;
-      const next = { ...prev, [roomId]: nms };
-      return next;
+      return { ...prev, [roomId]: nms };
     });
   };
   return {

--- a/frontend/src/stores/structure.ts
+++ b/frontend/src/stores/structure.ts
@@ -191,18 +191,20 @@ export const useUpdateMessage = () => {
     messageId: number,
     data: TD.ChatRoomMessage
   ) => {
-    const ms = messages[roomId];
-    if (!ms) {
-      return;
-    }
-    const i = ms.findIndex((m) => m.id === messageId);
-    if (i < 0) {
-      return;
-    }
-    const nms = [...ms];
-    nms[i] = data;
-    const newMessages = { ...messages, [roomId]: nms };
-    setMessages(newMessages);
+    setMessages((prev) => {
+      const ms = prev[roomId];
+      if (!ms) {
+        return prev;
+      }
+      const i = ms.findIndex((m) => m.id === messageId);
+      if (i < 0) {
+        return prev;
+      }
+      const nms = [...ms];
+      nms[i] = data;
+      const next = { ...prev, [roomId]: nms };
+      return next;
+    });
   };
   return {
     setOne,

--- a/frontend/src/stores/structure.ts
+++ b/frontend/src/stores/structure.ts
@@ -183,3 +183,28 @@ export const useUpdateJoiningRooms = () => {
   };
   return updater;
 };
+
+export const useUpdateMessage = () => {
+  const [messages, setMessages] = useAtom(structureAtom.messagesInRoomAtom);
+  const setOne = (
+    roomId: number,
+    messageId: number,
+    data: TD.ChatRoomMessage
+  ) => {
+    const ms = messages[roomId];
+    if (!ms) {
+      return;
+    }
+    const i = ms.findIndex((m) => m.id === messageId);
+    if (i < 0) {
+      return;
+    }
+    const nms = [...ms];
+    nms[i] = data;
+    const newMessages = { ...messages, [roomId]: nms };
+    setMessages(newMessages);
+  };
+  return {
+    setOne,
+  };
+};

--- a/frontend/src/typedef.ts
+++ b/frontend/src/typedef.ts
@@ -67,6 +67,7 @@ const MessageTypes = [
   'PR_START',
   'PR_RESULT',
   'PR_ERROR',
+  'PR_STATUS',
 ] as const;
 export type MessageType = typeof MessageTypes[number];
 
@@ -81,6 +82,7 @@ export type ChatRoomMessage = {
   content: string;
   messageType?: MessageType;
   subpayload?: any;
+  matchId?: string;
 };
 
 export type UserRelationMap = {
@@ -195,7 +197,8 @@ export const Mapper = {
       'createdAt',
       'content',
       'messageType',
-      'subpayload'
+      'subpayload',
+      'matchId'
     );
     if (r.user) {
       r.user = Mapper.user(r.user);

--- a/frontend/src/typedef.ts
+++ b/frontend/src/typedef.ts
@@ -180,6 +180,12 @@ export type ChatRoomResult = {
   data: Partial<ChatRoom>;
 };
 
+export type MessageUpdateResult = {
+  roomId: number;
+  messageId: number;
+  message: ChatRoomMessage;
+};
+
 export const Mapper = {
   user: (data: any): User => {
     return Utils.pick(data, 'id', 'displayName');


### PR DESCRIPTION
### タスクリスト

- [x] (B) `ChatMessage`がマッチの情報(ID)を持つようにする
- [x] (B) プライベートマッチ募集開始時にマッチングメッセージ(`PR_STATUS`)を生成して送信する
- [x] (F) マッチングメッセージのガワを作る
- [x] (B) プライベートマッチの状態変化の際にマッチングメッセージの中身を変更し、それをWSで通知する
  - タイミングはマッチシステムメッセージを出すタイミングと同じ
- [x] (F) 募集中の場合、マッチングメッセージから参加できるようにする
- [x] (F) 募集中の場合、マッチングメッセージからキャンセルできるようにする
- [x] (F) 進行中の場合、マッチングメッセージから観戦できるようにする
- [x] (F) 決着がついている場合、マッチングメッセージに結果を表示する
- [x] (B) スコアが入るたびにマッチングメッセージを更新

resolve #237

### マッチングメッセージが持つべき情報

- マッチID
- ルームID
- 募集ユーザのID
- (optional) 参加ユーザのID
- 以下はサブペイロード`subpayload`に入れる
- 現在状態
  - 募集中
  - キャンセル済み
  - ゲーム中
  - ゲーム終了
  - ゲーム以上終了
    - マッチシステムメッセージの種類と同じ
- (optional) 募集ユーザの得点
- (optional) 参加ユーザの得点

ペイロードの構造は
```ts
{
  status: 'PR_OPEN' | 'PR_CANCEL' | 'PR_START' | 'PR_RESULT' | 'PR_ERROR';
  userScore?: number;
  secondaryUserScore?: number;
};
```

