### PR TITLE
pongのゲーム部分のtodo消す

### DIFF
--- a/frontend/src/features/Pong/components/MatchPage.tsx
+++ b/frontend/src/features/Pong/components/MatchPage.tsx
@@ -44,14 +44,32 @@ export const PongMatchPage: React.FC<{ mySocket: ReturnType<typeof io> }> = (
       }
     });
 
-    const handleFinished = ({
+    const fetchUserName = async (id: string) => {
+      try {
+        const result = await fetcher('GET', `/users/${id}`);
+        if (!result.ok) {
+          throw new Error();
+        }
+        const json = await result.json();
+        return json.displayName;
+      } catch (error) {
+        return 'Error';
+      }
+    };
+
+    const handleFinished = async ({
       game,
       result,
     }: {
       game: GameState;
       result: GameResult;
     }) => {
-      drawGameResult(game, result);
+      const callApiPromises = game.players.map((item) =>
+        fetchUserName(item.id)
+      );
+
+      const playerNames = await Promise.all(callApiPromises);
+      drawGameResult(game, result, playerNames);
       setIsFinished(true);
     };
 

--- a/frontend/src/features/Pong/hooks/usePongGame.tsx
+++ b/frontend/src/features/Pong/hooks/usePongGame.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { GameResult, GameSettings, GameState } from '../types';
 import { useCanvasSize } from './useCanvasSize';
@@ -169,12 +170,12 @@ const drawResult = (
 export const usePongGame = (isFinished: boolean) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const canvasSize = useCanvasSize();
+  const navigate = useNavigate();
 
   const onClickResult = useCallback(() => {
     if (isFinished === false) return;
-    //TODO タイトルへ遷移
-    console.log('to title');
-  }, [isFinished]);
+    navigate('/');
+  }, [isFinished, navigate]);
 
   const renderGame = () => (
     <canvas

--- a/frontend/src/features/Pong/hooks/usePongGame.tsx
+++ b/frontend/src/features/Pong/hooks/usePongGame.tsx
@@ -131,7 +131,8 @@ const redrawGame = (
 const drawResult = (
   canvas: HTMLCanvasElement,
   game: GameState,
-  result: GameResult
+  result: GameResult,
+  names: string[]
 ) => {
   const ctx = canvas.getContext('2d');
   const { width, height } = canvas;
@@ -155,7 +156,7 @@ const drawResult = (
     ctx.font = '160px PixelMplus';
     drawCenteringText(ctx, player.score.toString(), x, y);
     ctx.font = '80px PixelMplus';
-    drawCenteringText(ctx, player.id, x, y + 120, 650); //TODO IDを名前に変える
+    drawCenteringText(ctx, names[i], x, y + 120, 650);
     ctx.font = '70px PixelMplus';
     drawCenteringText(ctx, resultText, x, y + 220);
   }
@@ -195,9 +196,13 @@ export const usePongGame = (isFinished: boolean) => {
       redrawGame(canvasRef.current, game, staticGameSettings);
     }
   };
-  const drawGameResult = (game: GameState, result: GameResult) => {
+  const drawGameResult = (
+    game: GameState,
+    result: GameResult,
+    names: string[]
+  ) => {
     if (canvasRef.current) {
-      drawResult(canvasRef.current, game, result);
+      drawResult(canvasRef.current, game, result, names);
     }
   };
 


### PR DESCRIPTION
## やったこと

- ゲームの勝敗画面でIDが表示されていたが、nameを表示するよう変更
- ゲームが終わった時、画面クリックでタイトル画面に遷移するよう変更