### PR TITLE
ゲーム終了後の不要なリクエストを防ぐ

### DIFF
--- a/frontend/src/features/Pong/hooks/usePongGame.tsx
+++ b/frontend/src/features/Pong/hooks/usePongGame.tsx
@@ -177,35 +177,38 @@ export const usePongGame = (isFinished: boolean) => {
     navigate('/');
   }, [isFinished, navigate]);
 
-  const renderGame = () => (
-    <canvas
-      id="pong"
-      ref={canvasRef}
-      width={staticGameSettings.field.width}
-      height={staticGameSettings.field.height}
-      //tailwindは動的にスタイル生成できないので、style属性で対応
-      style={{
-        width: canvasSize.width,
-        height: canvasSize.height,
-      }}
-      onClick={onClickResult}
-    />
+  const renderGame = useCallback(
+    () => (
+      <canvas
+        id="pong"
+        ref={canvasRef}
+        width={staticGameSettings.field.width}
+        height={staticGameSettings.field.height}
+        //tailwindは動的にスタイル生成できないので、style属性で対応
+        style={{
+          width: canvasSize.width,
+          height: canvasSize.height,
+        }}
+        onClick={onClickResult}
+      />
+    ),
+    [canvasSize.height, canvasSize.width, onClickResult]
   );
 
-  const drawGameOneFrame = (game: GameState) => {
+  const drawGameOneFrame = useCallback((game: GameState) => {
     if (canvasRef.current) {
       redrawGame(canvasRef.current, game, staticGameSettings);
     }
-  };
-  const drawGameResult = (
-    game: GameState,
-    result: GameResult,
-    names: string[]
-  ) => {
-    if (canvasRef.current) {
-      drawResult(canvasRef.current, game, result, names);
-    }
-  };
+  }, []);
+
+  const drawGameResult = useCallback(
+    (game: GameState, result: GameResult, names: string[]) => {
+      if (canvasRef.current) {
+        drawResult(canvasRef.current, game, result, names);
+      }
+    },
+    []
+  );
 
   return { renderGame, drawGameOneFrame, drawGameResult };
 };

--- a/frontend/src/hooks/useAPICaller.ts
+++ b/frontend/src/hooks/useAPICaller.ts
@@ -1,21 +1,26 @@
 import { useAtom } from 'jotai';
+import { useCallback } from 'react';
 
 import { storedCredentialAtom } from '@/stores/auth';
 
-export function useAPICallerWithCredential() {
+export const useAPICallerWithCredential = () => {
   const [credential] = useAtom(storedCredentialAtom);
-  return function (
-    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
-    endpoint: string,
-    option: {
-      credential?: any;
-      payloadFunc?: () => any;
-      payload?: any;
-    } = {}
-  ) {
-    return callAPI(method, endpoint, { ...option, credential });
-  };
-}
+
+  const callApiWithCredential = useCallback(
+    (
+      method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+      endpoint: string,
+      option: {
+        credential?: any;
+        payloadFunc?: () => any;
+        payload?: any;
+      } = {}
+    ) => callAPI(method, endpoint, { ...option, credential }),
+    [credential]
+  );
+
+  return callApiWithCredential;
+};
 
 export async function callAPI(
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',


### PR DESCRIPTION
## やったこと
- useApiCallerWithCredentialの返す関数がメモ化
- usePongGameの返す関数をメモ化
- ↑上記2つを行ったことで、Pongのゲーム画面で不用意に発火していたuseEffectが発火しなくなった