### PR TITLE
statsをユーザーページにも出す

### DIFF
--- a/frontend/src/features/User/MyPage.tsx
+++ b/frontend/src/features/User/MyPage.tsx
@@ -165,6 +165,9 @@ const MyPageContent = () => {
               </FTH1>
 
               <div className="flex flex-col">
+                <FTH3 className="flex min-w-0 flex-row items-center p-[4px] text-xl font-bold">
+                  Stats
+                </FTH3>
                 <UserStats id={user.id} />
               </div>
 

--- a/frontend/src/features/User/UserView.tsx
+++ b/frontend/src/features/User/UserView.tsx
@@ -19,6 +19,7 @@ import { BlockButton } from './components/BlockButton';
 import { FollowButton } from './components/FollowButton';
 import { MatchHistory } from './components/MatchHistory';
 import { ProfileBlock } from './components/ProfileBlock';
+import { UserStats } from './components/Stats';
 
 type ActualViewProps = {
   user: TD.User;
@@ -57,10 +58,14 @@ const ActualView = ({ user }: ActualViewProps) => {
           <FollowButton userId={user.id} isFriend={isFriend} />
           <BlockButton userId={user.id} isBlocking={isBlocking} />
         </div>
-        <FTH4>MatchHistory</FTH4>
-        <div className="px-2 py-4">
-          <MatchHistory id={user.id} />
-        </div>
+      </div>
+      <FTH4>Stats</FTH4>
+      <div className="px-2 py-4">
+        <UserStats id={user.id} />
+      </div>
+      <FTH4>MatchHistory</FTH4>
+      <div className="px-2 py-4">
+        <MatchHistory id={user.id} />
       </div>
     </>
   );

--- a/frontend/src/features/User/components/Stats.tsx
+++ b/frontend/src/features/User/components/Stats.tsx
@@ -58,9 +58,6 @@ export const UserStats = ({ id }: { id: number }) => {
 
   return (
     <>
-      <FTH3 className="flex min-w-0 flex-row items-center p-[4px] text-xl font-bold">
-        Stats
-      </FTH3>
       <ErrorBoundary>
         <Suspense fallback={<p>Loading...</p>}>
           <RenderStats


### PR DESCRIPTION
## やったこと
- userページにstatsを表示した
- DM周りがスッキリした影響か、Statsおいてみたら縦でもいけそうだったので縦置き

## スクショ
![スクリーンショット 2022-12-24 17 18 38](https://user-images.githubusercontent.com/62199197/209427680-b8e6e2d1-217b-4ffb-acab-61f7012fc1f8.png)
