### PR TITLE
同時に2つ以上のゲームに入れてしまうのを防ぐ

### DIFF
--- a/backend/src/pong/pong.gateway.ts
+++ b/backend/src/pong/pong.gateway.ts
@@ -85,7 +85,6 @@ export class PongGateway {
   // - 募集中のPrivateMatch
   // - OngoingMatches
   //上記いずれかに参加しているユーザーを弾く
-  //TODO: toastなどでエラーが発生したことをフロントで表示する
   validateUser = (userId: number) => {
     if (this.waitingQueues.getQueueByPlayerId(userId) !== undefined)
       return false;

--- a/backend/src/pong/pong.gateway.ts
+++ b/backend/src/pong/pong.gateway.ts
@@ -151,12 +151,14 @@ export class PongGateway {
     @MessageBody() data: PongMatchMakingEntryDTO
   ) {
     const user = getUserFromClient(client);
+    const queue = this.waitingQueues.getQueue(data.matchType);
 
-    if (this.validateUser(user.id) === false) return;
+    if (this.validateUser(user.id) === false || !queue)
+      return { status: 'rejected' };
 
     // 待機キューにユーザーを追加する
-    const queue = this.waitingQueues.getQueue(data.matchType);
-    queue?.append(user.id);
+    queue.append(user.id);
+    return { status: 'accepted' };
   }
 
   @SubscribeMessage('pong.match_making.leave')

--- a/backend/src/pong/pong.gateway.ts
+++ b/backend/src/pong/pong.gateway.ts
@@ -132,7 +132,7 @@ export class PongGateway {
   ) {
     const user = getUserFromClient(client);
 
-    if (this.validateUser(user.id) === false) return;
+    if (this.validateUser(user.id) === false) return { status: 'rejected' };
 
     this.pendingPrivateMatches.joinPrivateMatch(data.matchId, user.id);
   }

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -154,8 +154,6 @@ export class PongService {
         userScore2: 0,
         startAt: new Date(),
 
-        // TODO: Configを実装したらベタ書きを辞める
-        // TODO: Configを非Nullableにする
         config: {
           create: {
             maxScore: match.maxScore ?? Match.defaultConfig.maxScore,

--- a/frontend/src/components/ChatMatchingMessageCard.tsx
+++ b/frontend/src/components/ChatMatchingMessageCard.tsx
@@ -1,5 +1,6 @@
 import { useAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 
 import { makeCommand } from '@/features/Chat/command';
 import { InlineIcon } from '@/hocs/InlineIcon';
@@ -77,8 +78,18 @@ const PlayerCard = ({
       ) : (
         <CommandButton
           text="対戦する"
-          onClick={confirm('このプライベートマッチに参加しますか？', () =>
-            command.pong_private_match_join(matchId)
+          onClick={confirm(
+            'このプライベートマッチに参加しますか？',
+            async () => {
+              try {
+                await command.pong_private_match_join(matchId);
+              } catch (e) {
+                const error = e as any;
+                if (error.status === 'rejected') {
+                  toast('マッチに参加できません');
+                }
+              }
+            }
           )}
         />
       );

--- a/frontend/src/features/Pong/components/PrivateMatchCard.tsx
+++ b/frontend/src/features/Pong/components/PrivateMatchCard.tsx
@@ -1,5 +1,6 @@
 import { useAtom } from 'jotai';
 import { useState } from 'react';
+import { toast } from 'react-toastify';
 
 import {
   FTBlockedHeader,
@@ -56,8 +57,12 @@ export const PrivateMatchCard = ({ room, onSucceeded, onCancel }: Prop) => {
         // ネットワークエラー
       } else {
         const ne = e as any;
-        if (ne.status === 'rejected' && typeof ne.errors === 'object') {
-          setNetErrors(ne.errors);
+        if (ne.status === 'rejected') {
+          if (typeof ne.errors === 'object') {
+            setNetErrors(ne.errors);
+          } else {
+            toast('マッチを作成することができません');
+          }
         }
       }
     }

--- a/frontend/src/features/Pong/components/PrivateMatchCard.tsx
+++ b/frontend/src/features/Pong/components/PrivateMatchCard.tsx
@@ -51,6 +51,7 @@ export const PrivateMatchCard = ({ room, onSucceeded, onCancel }: Prop) => {
         speed: gameSpeedFactorStr,
       });
       console.log('result', result);
+      toast('マッチを作成しました');
       onSucceeded();
     } catch (e) {
       if (e instanceof TypeError) {

--- a/frontend/src/features/Pong/components/TopPage.tsx
+++ b/frontend/src/features/Pong/components/TopPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import { io } from 'socket.io-client';
 
 import { Modal } from '@/components/Modal';
@@ -21,7 +22,17 @@ export const PongTopPage = (props: { mySocket: ReturnType<typeof io> }) => {
     if (isWaiting) {
       return;
     }
-    mySocket.emit('pong.match_making.entry', { matchType: matchType });
+    mySocket.emit(
+      'pong.match_making.entry',
+      { matchType: matchType },
+      (result: any) => {
+        if (result && result.status === 'accepted') {
+          setIsWaiting(true);
+          return;
+        }
+        toast('マッチに参加できません');
+      }
+    );
   };
 
   return (
@@ -42,14 +53,12 @@ export const PongTopPage = (props: { mySocket: ReturnType<typeof io> }) => {
           <CommandCard
             text="カジュアルマッチをプレイ"
             onClick={() => {
-              setIsWaiting(true);
               startMatchMaking('CASUAL');
             }}
           />
           <CommandCard
             text="ランクマッチをプレイ"
             onClick={() => {
-              setIsWaiting(true);
               startMatchMaking('RANK');
             }}
           />


### PR DESCRIPTION
close #299 
close #311

## やったこと
```
  // - 待機キュー
  // - 募集中のPrivateMatch
  // - OngoingMatches
  //上記いずれかに参加しているユーザーを弾く
```
- プライベートマッチの作成、参加、対戦待機キューへの参加時に、バリデーションをする
- バリデーションに引っかかった場合、エラー用のトーストを出す。
- プライベートマッチ作成時にもトーストを足した
