### PR TITLE
`<UserForm>`の改善

### DIFF
--- a/frontend/src/features/DevAuth/UserForm.tsx
+++ b/frontend/src/features/DevAuth/UserForm.tsx
@@ -14,6 +14,7 @@ import { Icons } from '@/icons';
 import { UserPersonalData } from '@/stores/auth';
 import * as TD from '@/typedef';
 import { omitBy } from '@/utils';
+import { DisplayNamePolicy, PasswordPolicy } from '@/validator/user.validator';
 
 import { popAuthError } from '../Toaster/toast';
 import { AvatarFile, AvatarInput } from '../User/components/AvatarInput';
@@ -127,7 +128,6 @@ export const UserForm = ({ userData, onClose }: InnerProp) => {
         name="email"
         className="w-full border-0 border-b-2 focus:bg-gray-700"
         autoComplete="off"
-        placeholder="Email:"
         value={email}
         onActualKeyDown={moveFocus}
         onChange={(e) => setEmail(e.target.value)}
@@ -161,6 +161,10 @@ export const UserForm = ({ userData, onClose }: InnerProp) => {
   };
   const submitContent =
     mode === 'Create' ? <>この内容で登録</> : <>修正して保存</>;
+  const passwordPlaceholder =
+    mode === 'Create'
+      ? `${PasswordPolicy.min} - ${PasswordPolicy.max} 文字`
+      : `設定する場合は ${PasswordPolicy.min} - ${PasswordPolicy.max} 文字`;
   return (
     <>
       <FTH1 className="p-2 text-3xl">{title}</FTH1>
@@ -187,7 +191,7 @@ export const UserForm = ({ userData, onClose }: InnerProp) => {
               name="displayName"
               className="w-full border-0 border-b-2 focus:bg-gray-700"
               autoComplete="off"
-              placeholder="Name:"
+              placeholder={`${DisplayNamePolicy.min} - ${DisplayNamePolicy.max} 文字`}
               value={displayName}
               onActualKeyDown={moveFocus}
               onChange={(e) => setDisplayName(e.target.value)}
@@ -207,7 +211,7 @@ export const UserForm = ({ userData, onClose }: InnerProp) => {
               name="password"
               className="w-full border-0 border-b-2 focus:bg-gray-700"
               autoComplete="off"
-              placeholder="設定する場合は 12 - 60 文字"
+              placeholder={passwordPlaceholder}
               value={password}
               type="password"
               onActualKeyDown={moveFocus}

--- a/frontend/src/features/DevAuth/UserForm.tsx
+++ b/frontend/src/features/DevAuth/UserForm.tsx
@@ -166,15 +166,15 @@ export const UserForm = ({ userData, onClose }: InnerProp) => {
       <FTH1 className="p-2 text-3xl">{title}</FTH1>
       {headerBlock}
       <div className="flex">
-        <div>
-          <FTH4 style={{ paddingLeft: '1em' }}>avatar</FTH4>
-          <div className="p-[1em]">
-            <AvatarInput
-              avatarFile={avatarFile}
-              setAvatarFile={setAvatarFile}
-              networkError={netErrors.avatar}
-            />
-          </div>
+        <div className="flex shrink-0 grow-0 flex-col">
+          <FTH4>
+            <span className="pl-4">avatar</span>
+          </FTH4>
+          <AvatarInput
+            avatarFile={avatarFile}
+            setAvatarFile={setAvatarFile}
+            networkError={netErrors.avatar}
+          />
         </div>
 
         <div className="shrink grow overflow-hidden">

--- a/frontend/src/features/User/components/AvatarInput.tsx
+++ b/frontend/src/features/User/components/AvatarInput.tsx
@@ -102,17 +102,13 @@ export const AvatarInput = ({
         </div>
         {avatarFile && (
           <div
-            className="max-h-[6em] shrink grow overflow-hidden text-ellipsis text-sm"
+            className="max-h-[6em] shrink grow overflow-hidden text-ellipsis break-all text-sm"
             title={avatarFile.name}
-            style={{ wordBreak: 'break-all' }}
           >
             {avatarFile.name}
           </div>
         )}
-        <div
-          className="shrink-0 grow-0 overflow-hidden text-ellipsis text-sm text-red-400"
-          style={{ wordBreak: 'break-all' }}
-        >
+        <div className="shrink-0 grow-0 overflow-hidden text-ellipsis break-all text-sm text-red-400">
           {validationErrors.avatar || networkError || '　'}
         </div>
       </div>

--- a/frontend/src/features/User/components/AvatarInput.tsx
+++ b/frontend/src/features/User/components/AvatarInput.tsx
@@ -104,11 +104,15 @@ export const AvatarInput = ({
           <div
             className="max-h-[6em] shrink grow overflow-hidden text-ellipsis text-sm"
             title={avatarFile.name}
+            style={{ wordBreak: 'break-all' }}
           >
             {avatarFile.name}
           </div>
         )}
-        <div className="shrink-0 grow-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-red-400">
+        <div
+          className="shrink-0 grow-0 overflow-hidden text-ellipsis text-sm text-red-400"
+          style={{ wordBreak: 'break-all' }}
+        >
           {validationErrors.avatar || networkError || '　'}
         </div>
       </div>

--- a/frontend/src/features/User/components/AvatarInput.tsx
+++ b/frontend/src/features/User/components/AvatarInput.tsx
@@ -92,16 +92,23 @@ export const AvatarInput = ({
   })();
   return (
     <>
-      <div>
+      <div className="m-4 flex w-[120px] shrink-0 grow-0 flex-col items-stretch overflow-hidden">
         <div
           {...getRootProps()}
-          className="h-[120px] w-[120px] cursor-pointer border-[1px] border-dotted border-white"
+          className="h-[120px] shrink-0 grow-0 cursor-pointer border-[1px] border-dotted border-white"
         >
           <input {...getInputProps()} />
           {innerDropZone}
         </div>
-        {avatarFile && <div className="text-sm">{avatarFile.name}</div>}
-        <div className="text-sm text-red-400">
+        {avatarFile && (
+          <div
+            className="max-h-[6em] shrink grow overflow-hidden text-ellipsis text-sm"
+            title={avatarFile.name}
+          >
+            {avatarFile.name}
+          </div>
+        )}
+        <div className="shrink-0 grow-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-red-400">
           {validationErrors.avatar || networkError || '　'}
         </div>
       </div>

--- a/frontend/src/validator/user.validator.ts
+++ b/frontend/src/validator/user.validator.ts
@@ -1,17 +1,18 @@
 import { keyBy } from '@/utils';
 
+export const DisplayNamePolicy = {
+  min: 1,
+  max: 20,
+} as const;
+
 export const validateDisplayName = (s: string) => {
   const trimmed = s.trim();
-  const policy = {
-    min: 1,
-    max: 20,
-  };
-  if (!trimmed) {
-    return 'empty?';
-  }
   const n = trimmed.length;
-  if (n > policy.max) {
-    return `${n}/${policy.max} too long`;
+  if (!n) {
+    return `${n}/${DisplayNamePolicy.max} too short`;
+  }
+  if (n > DisplayNamePolicy.max) {
+    return `${n}/${DisplayNamePolicy.max} too long`;
   }
   return null;
 };
@@ -29,34 +30,35 @@ export const validateEmail = (s: string) => {
   return null;
 };
 
+export const PasswordPolicy = {
+  min: 12,
+  max: 60,
+  types: 4,
+  usableCharacters: /^[A-Za-z0-9/_-]+$/,
+} as const;
+
 /**
  * 登録用に厳しくバリデーションする
  */
 export const validatePassword = (s: string, required: boolean) => {
   const trimmed = s.trim();
-  const policy = {
-    min: 12,
-    max: 60,
-    types: 4,
-    usableCharacters: /^[A-Za-z0-9/_-]+$/,
-  };
   const n = trimmed.length;
   if (n === 0) {
     if (!required) {
       return null;
     }
   }
-  if (n < policy.min) {
-    return `${n}/${policy.min} too short`;
+  if (n < PasswordPolicy.min) {
+    return `${n}/${PasswordPolicy.min} too short`;
   }
-  if (policy.max < n) {
-    return `${n}/${policy.max} too long`;
+  if (PasswordPolicy.max < n) {
+    return `${n}/${PasswordPolicy.max} too long`;
   }
   const characters = Object.keys(keyBy(trimmed.split(''), (c) => c));
-  if (characters.length < policy.types) {
-    return `too less character types (${characters.length}/${policy.types})`;
+  if (characters.length < PasswordPolicy.types) {
+    return `too less character types (${characters.length}/${PasswordPolicy.types})`;
   }
-  if (!trimmed.match(policy.usableCharacters)) {
+  if (!trimmed.match(PasswordPolicy.usableCharacters)) {
     return 'unusable character detected';
   }
   return null;


### PR DESCRIPTION
- [x] アバター画像のファイル名が長いとレイアウトが崩れる
- [x] パスワード欄のプレースホルダが不自然
- [x] 名前・メアドのプレースホルダも変更


### TODOタスク

- 名前のエラー欄の表示をパスワードと同じようにする
- 名前・パスワードのバリデーションを統一
