### PR TITLE
チャットルームの作成・編集モーダルでルームタイプを変更しようとすると見切れる

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -70,7 +70,7 @@ export const Modal = ({
           <div className="fixed inset-0 z-50 flex flex-1 flex-col items-center justify-center gap-32">
             <div className="flex max-h-[100%] w-full flex-col items-center overflow-y-scroll p-2">
               <div className="flex items-center justify-center">
-                <Dialog.Panel className="mx-auto rounded bg-primary">
+                <Dialog.Panel className="mx-auto rounded">
                   {children}
                 </Dialog.Panel>
               </div>

--- a/frontend/src/features/Chat/RoomSetting.tsx
+++ b/frontend/src/features/Chat/RoomSetting.tsx
@@ -85,7 +85,7 @@ const CardElement = ({
             <div>
               <SelectListBox<TD.RoomType>
                 selected={roomType}
-                items={[...TD.RoomTypes]}
+                items={[...TD.RoomTypesSelectable]}
                 setItem={setRoomType}
                 makeElement={(t) => {
                   const Icon = RoomTypeIcon[t];

--- a/frontend/src/features/Chat/RoomSetting.tsx
+++ b/frontend/src/features/Chat/RoomSetting.tsx
@@ -56,7 +56,7 @@ const CardElement = ({
 }: ElementProps) => {
   return (
     <>
-      <div className="flex w-96 flex-col border-2 border-solid border-white bg-black">
+      <div className="mb-[2em] flex w-96 flex-col border-2 border-solid border-white bg-black">
         <FTBlockedHeader>
           <FTButton onClick={onCancel} className="shrink-0 grow-0">
             <Icons.Cancel className="block" />
@@ -90,7 +90,7 @@ const CardElement = ({
                 makeElement={(t) => {
                   const Icon = RoomTypeIcon[t];
                   return (
-                    <div className="flex flex-row justify-center">
+                    <div className="z-50 flex flex-row justify-center">
                       <InlineIcon i={<Icon />} />
                       <p className="basis-[4em]">{t}</p>
                     </div>

--- a/frontend/src/features/DevAuth/AuthCard.tsx
+++ b/frontend/src/features/DevAuth/AuthCard.tsx
@@ -58,7 +58,7 @@ export const TotpAuthForm = (props: {
   });
 
   return (
-    <div className="flex w-[480px] flex-col justify-around gap-5 p-8">
+    <div className="flex w-[480px] flex-col justify-around gap-5 bg-primary p-8">
       <h3>ワンタイムパスワード入力</h3>
       <ul className="list-disc">
         <li>

--- a/frontend/src/features/User/MyPage.tsx
+++ b/frontend/src/features/User/MyPage.tsx
@@ -64,13 +64,13 @@ const MyPageContent = () => {
     switch (modalType) {
       case 'edit':
         return (
-          <div className="flex w-[480px] flex-col justify-around gap-5 p-8">
+          <div className="flex w-[480px] flex-col justify-around gap-5 bg-primary p-8">
             <EditProfileCard user={user} onClose={() => setIsOpen(false)} />
           </div>
         );
       case 'password':
         return (
-          <div className="flex w-[480px] flex-col justify-around gap-5 p-8">
+          <div className="flex w-[480px] flex-col justify-around gap-5 bg-primary p-8">
             <EditPasswordCard user={user} onClose={() => setIsOpen(false)} />
           </div>
         );

--- a/frontend/src/features/User/components/AuthBlock.tsx
+++ b/frontend/src/features/User/components/AuthBlock.tsx
@@ -23,7 +23,7 @@ const urlGA = {
  */
 const QrcodeCard = (props: { qrcode: string; onClose: () => void }) => {
   return (
-    <div className="flex w-[480px] flex-col justify-around gap-5 p-8">
+    <div className="flex w-[480px] flex-col justify-around gap-5 bg-primary p-8">
       <h3>二要素認証用QRコード</h3>
       <ul className="list-disc">
         <li>

--- a/frontend/src/hooks/useConfirmModal.tsx
+++ b/frontend/src/hooks/useConfirmModal.tsx
@@ -108,7 +108,7 @@ export const useConfirmModalComponent = () => {
     };
     return (
       <Modal isOpen={isOpen} closeModal={denialCloser}>
-        <div className="flex min-w-[180px] flex-col p-4">
+        <div className="flex min-w-[180px] flex-col bg-primary p-4">
           <div className="flex flex-row justify-center p-4">
             <p className="shrink-0 grow-0">{arg.body}</p>
           </div>


### PR DESCRIPTION
### サブタスク

- [x] そもそもルームタイプとして`DM`が選べるのはまずいので選べないようにする。
- [x] このモーダルだけ下に2emだけマージンを明ける。
  - [x] そうすると色がつくので、透明にする。