### PR TITLE
ブラウザ補完の挙動修正

### DIFF
--- a/frontend/src/features/Chat/RoomSetting.tsx
+++ b/frontend/src/features/Chat/RoomSetting.tsx
@@ -105,14 +105,16 @@ const CardElement = ({
           <div className="flex flex-row p-2">
             <div className="basis-[6em] p-2">PASSWORD</div>
             <div className="shrink grow">
-              <FTTextField
-                className="w-full border-2"
-                type="password"
-                autoComplete="off"
-                value={roomPassword}
-                placeholder={placeholder.password || '4文字以上 40文字以下'}
-                onChange={(e) => setRoomPassword(e.target.value)}
-              />
+              <form>
+                <FTTextField
+                  className="w-full border-2"
+                  type="password"
+                  autoComplete="off"
+                  value={roomPassword}
+                  placeholder={placeholder.password || '4文字以上 40文字以下'}
+                  onChange={(e) => setRoomPassword(e.target.value)}
+                />
+              </form>
               <div>{errors.roomPassword || '　'}</div>
             </div>
           </div>

--- a/frontend/src/features/Chat/RoomSetting.tsx
+++ b/frontend/src/features/Chat/RoomSetting.tsx
@@ -108,7 +108,7 @@ const CardElement = ({
               <form>
                 <FTTextField
                   className="w-full border-2"
-                  type="password"
+                  type="text"
                   autoComplete="off"
                   value={roomPassword}
                   placeholder={placeholder.password || '4文字以上 40文字以下'}

--- a/frontend/src/features/Chat/components/RoomPasswordInput.tsx
+++ b/frontend/src/features/Chat/components/RoomPasswordInput.tsx
@@ -24,7 +24,7 @@ export const RoomPasswordInput = ({
         <FTTextField
           className="w-full border-2"
           autoComplete="one-time-code"
-          type="password"
+          type="text"
           value={roomPassword}
           placeholder="room password"
           onChange={(e) => setRoomPassword(e.target.value)}

--- a/frontend/src/features/Chat/components/RoomPasswordInput.tsx
+++ b/frontend/src/features/Chat/components/RoomPasswordInput.tsx
@@ -23,7 +23,7 @@ export const RoomPasswordInput = ({
       <div className="p-2">
         <FTTextField
           className="w-full border-2"
-          type="password"
+          type="text"
           value={roomPassword}
           placeholder="room password"
           onChange={(e) => setRoomPassword(e.target.value)}

--- a/frontend/src/features/DevAuth/AuthCard.tsx
+++ b/frontend/src/features/DevAuth/AuthCard.tsx
@@ -186,27 +186,29 @@ const PasswordAuthForm = (props: {
 
   return (
     <div className="grid grid-flow-row justify-center">
-      <div>
-        <FTTextField
-          className="border-2"
-          autoComplete="off"
-          placeholder="メールアドレス"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <div>{validationErrors.email || netErrors.email || '　'}</div>
-      </div>
-      <div>
-        <FTTextField
-          className="border-2"
-          autoComplete="off"
-          placeholder="パスワード"
-          value={password}
-          type="password"
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <div>{validationErrors.password || netErrors.password || '　'}</div>
-      </div>
+      <form id="signInForm">
+        <div>
+          <FTTextField
+            className="border-2"
+            autoComplete="username"
+            placeholder="メールアドレス"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <div>{validationErrors.email || netErrors.email || '　'}</div>
+        </div>
+        <div>
+          <FTTextField
+            className="border-2"
+            autoComplete="current-password"
+            placeholder="パスワード"
+            value={password}
+            type="password"
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <div>{validationErrors.password || netErrors.password || '　'}</div>
+        </div>
+      </form>
       <div>
         <FTButton
           disabled={validationErrors.some || state === 'Fetching'}

--- a/frontend/src/features/DevAuth/UserForm.tsx
+++ b/frontend/src/features/DevAuth/UserForm.tsx
@@ -178,7 +178,7 @@ export const UserForm = ({ userData, onClose }: InnerProp) => {
             </div>
           </div>
 
-          <form id="userForm">
+          <form id="userSignUpForm">
             <FTH4>email</FTH4>
             <div className="overflow-hidden truncate py-1 pr-1">
               <FTTextField

--- a/frontend/src/features/DevAuth/UserForm.tsx
+++ b/frontend/src/features/DevAuth/UserForm.tsx
@@ -118,25 +118,6 @@ export const UserForm = ({ userData, onClose }: InnerProp) => {
       <p className=" pt-1 pr-1 pb-4">{userData.id}</p>
     </>
   ) : null;
-  const emailBlock = userData ? (
-    <>{userData.email}</>
-  ) : (
-    <>
-      <FTTextField
-        id={emailId}
-        name="email"
-        className="w-full border-0 border-b-2 focus:bg-gray-700"
-        autoComplete="off"
-        placeholder="Email:"
-        value={email}
-        onActualKeyDown={moveFocus}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <div className="text-red-400">
-        {validationErrors.email || netErrors.email || '　'}
-      </div>
-    </>
-  );
   const passwordErrorContent = () => {
     const passwordError = validationErrors.password || netErrors.password;
     if (passwordError) {
@@ -197,24 +178,41 @@ export const UserForm = ({ userData, onClose }: InnerProp) => {
             </div>
           </div>
 
-          <FTH4>email</FTH4>
-          <div className="overflow-hidden truncate py-1 pr-1">{emailBlock}</div>
+          <form id="userForm">
+            <FTH4>email</FTH4>
+            <div className="overflow-hidden truncate py-1 pr-1">
+              <FTTextField
+                id={emailId}
+                name="email"
+                className="w-full border-0 border-b-2 focus:bg-gray-700"
+                autoComplete="username"
+                placeholder="Email:"
+                value={userData ? userData.email : email}
+                onActualKeyDown={moveFocus}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={!!userData}
+              />
+              <div className="text-red-400">
+                {validationErrors.email || netErrors.email || '　'}
+              </div>
+            </div>
 
-          <FTH4 className="">password</FTH4>
-          <div className="py-1">
-            <FTTextField
-              id={passwordId}
-              name="password"
-              className="w-full border-0 border-b-2 focus:bg-gray-700"
-              autoComplete="off"
-              placeholder="設定する場合は 12 - 60 文字"
-              value={password}
-              type="password"
-              onActualKeyDown={moveFocus}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-            <div className="h-[2em]">{passwordErrorContent()}</div>
-          </div>
+            <FTH4 className="">password</FTH4>
+            <div className="py-1">
+              <FTTextField
+                id={passwordId}
+                name="password"
+                className="w-full border-0 border-b-2 focus:bg-gray-700"
+                autoComplete="new-password"
+                placeholder="設定する場合は 12 - 60 文字"
+                value={password}
+                type="password"
+                onActualKeyDown={moveFocus}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <div className="h-[2em]">{passwordErrorContent()}</div>
+            </div>
+          </form>
         </div>
       </div>
       <div className="flex justify-around p-4">


### PR DESCRIPTION
resolve #294 

確認したこと（chromeのみ
- メールパスワード、42Authの認証でユーザーを登録するとき、メールとパスワードがブラウザに保存されるようにする
- /authのメール、パスワード入力欄に、保存したメール、パスワードが補完される
- パスワード付きチャットルームの作成フォームで保存したパスワードが補完されない
- パスワード付きチャットルームを作成したとき、新しいパスワードとして保存するか聞かれない
  - ~~submit前にinput要素のtypeをpasswordから変更する or そもそもtextにすれば解決しそう~~
  - ぜんぜん分かんなかったのでとりあえずtextで