### PR TITLE
反射後の角度に揺らぎを持たせる

### DIFF
--- a/backend/src/pong/game/match.ts
+++ b/backend/src/pong/game/match.ts
@@ -1,3 +1,5 @@
+import { isfinite } from 'src/utils';
+
 import { GameSettings } from './types/game-settings';
 import {
   Ball,
@@ -146,24 +148,29 @@ export class Match {
     }
   };
 
+  makeBallRect(center: Vector2d): Rectangle {
+    return {
+      topLeft: {
+        x: center.x - Match.ballRadius,
+        y: center.y - Match.ballRadius,
+      },
+      bottomRight: {
+        x: center.x + Match.ballRadius,
+        y: center.y + Match.ballRadius,
+      },
+    };
+  }
+
   // ball の位置を更新する
   updateBall = (): void => {
     let newVelocity: Vector2d = JSON.parse(JSON.stringify(this.ball.velocity));
     const newBallPos: Vector2d = JSON.parse(JSON.stringify(this.ball.position));
     newBallPos.x += this.ball.velocity.x * Match.ballDx;
     newBallPos.y += this.ball.velocity.y * Match.ballDy;
+    const ballRect = this.makeBallRect(this.ball.position);
 
     // バーとの判定
-    const newBallRect: Rectangle = {
-      topLeft: {
-        x: newBallPos.x - Match.ballRadius,
-        y: newBallPos.y - Match.ballRadius,
-      },
-      bottomRight: {
-        x: newBallPos.x + Match.ballRadius,
-        y: newBallPos.y + Match.ballRadius,
-      },
-    };
+    const newBallRect = this.makeBallRect(newBallPos);
     const velocityMag = Math.sqrt(
       newVelocity.x * newVelocity.x + newVelocity.y * newVelocity.y
     );
@@ -191,6 +198,9 @@ export class Match {
         bottomLeft: rot(re.bottomLeft),
       };
     };
+    let tx = Infinity;
+    let ty = Infinity;
+    let bcx = NaN;
     for (let idx = 0; idx < 2; idx++) {
       const player = this.players[idx];
       if (!this.isReactanglesOverlap(newBallRect, player.bar)) {
@@ -204,52 +214,71 @@ export class Match {
       //    衝突判定は "ボールとバーの1辺同士が交差するかどうか" を判定する問題になるので, それを解く.
       const rotatedBall = rotRect(makeFullRectangle(newBallRect));
       const rotatedBar = rotRect(makeFullRectangle(player.bar));
-      if (newVelocity.x >= 0) {
+      if (newVelocity.x > 0) {
         // 右側に進んでいる -> ボール右辺とバー左辺の衝突を判定する
         const ballSide = makeEdge(rotatedBall, 'y', 'right');
         const barSide = makeEdge(rotatedBar, 'y', 'left');
         if (areRangesOverlap(ballSide, barSide)) {
-          newVelocity = {
-            x: this.ball.velocity.x * -1,
-            y: this.ball.velocity.y,
-          };
-          break;
+          const dx = player.bar.topLeft.x - ballRect.bottomRight.x;
+          const vx = newVelocity.x;
+          tx = Math.abs(dx / vx);
+          bcx = (player.bar.topLeft.y + player.bar.bottomRight.y) / 2;
         }
-      } else {
+      } else if (newVelocity.x < 0) {
         // 左側に進んでいる -> ボール左辺とバー右辺の衝突を判定する
         const ballSide = makeEdge(rotatedBall, 'y', 'left');
         const barSide = makeEdge(rotatedBar, 'y', 'right');
         if (areRangesOverlap(ballSide, barSide)) {
-          newVelocity = {
-            x: this.ball.velocity.x * -1,
-            y: this.ball.velocity.y,
-          };
-          break;
+          const dx = player.bar.bottomRight.x - ballRect.topLeft.x;
+          const vx = newVelocity.x;
+          tx = Math.abs(dx / vx);
+          bcx = (player.bar.topLeft.y + player.bar.bottomRight.y) / 2;
         }
       }
-      if (newVelocity.y <= 0) {
+      if (newVelocity.y < 0) {
         // 上側に進んでいる -> ボール上辺とバー下辺の衝突を判定する
         const ballSide = makeEdge(rotatedBall, 'y', 'top');
         const barSide = makeEdge(rotatedBar, 'y', 'bottom');
         if (areRangesOverlap(ballSide, barSide)) {
-          newVelocity = {
-            x: this.ball.velocity.x,
-            y: this.ball.velocity.y * -1,
-          };
-          break;
+          const dy = player.bar.bottomRight.y - ballRect.topLeft.y;
+          const vy = newVelocity.y;
+          ty = Math.abs(dy / vy);
         }
-      } else {
+      } else if (newVelocity.y > 0) {
         // 下側に進んでいる -> ボール下辺とバー上辺の衝突を判定する
         const ballSide = makeEdge(rotatedBall, 'y', 'bottom');
         const barSide = makeEdge(rotatedBar, 'y', 'top');
         if (areRangesOverlap(ballSide, barSide)) {
-          newVelocity = {
-            x: this.ball.velocity.x,
-            y: this.ball.velocity.y * -1,
-          };
-          break;
+          const dy = player.bar.topLeft.y - ballRect.bottomRight.y;
+          const vy = newVelocity.y;
+          ty = Math.abs(dy / vy);
         }
       }
+    }
+
+    if (tx <= ty && isfinite(tx)) {
+      // X方向反射 → 角度揺らぎがある
+      newVelocity.x = -newVelocity.x;
+      const v = Math.sqrt(newVelocity.x ** 2 + newVelocity.y ** 2);
+      const deltaPi = (Math.PI / 180) * 30;
+      const ballCenter = this.ball.position.y + newVelocity.y * tx;
+      const r = ((ballCenter - bcx) * 2) / Match.barHeight;
+      const r4 = r ** 4;
+      const deltaPhi = (Math.PI / 180) * 180 * r4 * (Math.random() / 2 - 1);
+      const rev = newVelocity.x > 0 ? +1 : -1;
+      const pphi = Math.atan2(newVelocity.y, rev * newVelocity.x);
+      const phi = cramp(
+        -Math.PI / 2 + deltaPi,
+        pphi + deltaPhi,
+        Math.PI / 2 - deltaPi
+      );
+      newVelocity = {
+        x: rev * v * Math.cos(phi),
+        y: v * Math.sin(phi),
+      };
+    } else if (ty <= tx && isfinite(ty)) {
+      // Y方向反射 → 揺らがせない
+      newVelocity.y = -newVelocity.y;
     }
 
     // 上下の壁との判定
@@ -429,6 +458,10 @@ function makeEdge(
     case 'right':
       return sort2array([rect.topRight[xy], rect.bottomRight[xy]]);
   }
+}
+
+function cramp(min: number, x: number, max: number) {
+  return Math.max(min, Math.min(max, x));
 }
 
 /**


### PR DESCRIPTION
### 揺らぎのメカニズム

- `r = (反射時のボールの中心のY座標 - バーの中心のY座標) / バーの長さ * 2`とする。
  - `-1 <= r <= +r`
- `Δφ = (r ^ 4) * 90度 * (rand() / 2 - 1)`を角度揺らぎとする。
  - rを4乗するのは、バーの中央で反射した場合はあまり揺らがず、バーの端に当てた場合は極端に揺らぐようにするため。
- 反射後の方向角φに角度揺らぎΔφを加える
- 方向角φが`-60度 <= φ <= +60度`を満たすようにφを調整する

※以上は反射後の進行方向が画面右側である場合。左側に進む場合は適当に変換する(変数`rev`)。