### PR TITLE
joinしてないチャットルームのurlにアクセスしても一見入室しているかのように見えてしまう

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -795,7 +795,6 @@ export class ChatGateway implements OnGatewayConnection {
     @ConnectedSocket() client: Socket
   ) {
     const user = getUserFromClient(client);
-    this.pulse(user);
     const messages = await this.chatRoomService.getMessages(user, {
       roomId: data.roomId,
       take: data.take,
@@ -811,6 +810,7 @@ export class ChatGateway implements OnGatewayConnection {
         client,
       }
     );
+    this.pulse(user);
   }
 
   /**
@@ -825,7 +825,6 @@ export class ChatGateway implements OnGatewayConnection {
     @ConnectedSocket() client: Socket
   ) {
     const user = getUserFromClient(client);
-    this.pulse(user);
     const members = await this.chatRoomService.getMembers(user, data.roomId);
     this.wsServer.sendResults(
       'ft_get_room_members',
@@ -837,6 +836,7 @@ export class ChatGateway implements OnGatewayConnection {
         client,
       }
     );
+    this.pulse(user);
   }
 
   @SubscribeMessage('ft_follow')

--- a/frontend/src/features/Chat/ChatRoomView.tsx
+++ b/frontend/src/features/Chat/ChatRoomView.tsx
@@ -1,38 +1,14 @@
-import { useAtom } from 'jotai';
-import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { authAtom, chatSocketAtom } from '@/stores/auth';
 import { useRoomDataReadOnly } from '@/stores/store';
-import { dataAtom } from '@/stores/structure';
 
-import { makeCommand } from './command';
 import { RoomView } from './components/RoomView';
 
 export const ChatRoomView = () => {
   const { id } = useParams();
   const room = useRoomDataReadOnly(parseInt(id || ''));
-  const [mySocket] = useAtom(chatSocketAtom);
-  const [personalData] = useAtom(authAtom.personalData);
-  const [members] = dataAtom.useMembersInRoom(room?.id || -1);
-  const membersExists = !!members;
-  useEffect(() => {
-    if (!room || !mySocket || !personalData || membersExists) {
-      return;
-    }
-    const command = makeCommand(mySocket, room.id);
-    command.get_room_members(room.id);
-  }, [membersExists, mySocket, personalData, room]);
-  if (!room || !mySocket || !personalData) {
+  if (!room) {
     return null;
   }
-  return (
-    <RoomView
-      domain="chat"
-      room={room}
-      roomName={room.roomName}
-      mySocket={mySocket}
-      personalData={personalData}
-    />
-  );
+  return <RoomView domain="chat" room={room} />;
 };

--- a/frontend/src/features/Chat/ChatRoomView.tsx
+++ b/frontend/src/features/Chat/ChatRoomView.tsx
@@ -1,9 +1,12 @@
 import { useAtom } from 'jotai';
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { authAtom, chatSocketAtom } from '@/stores/auth';
 import { useRoomDataReadOnly } from '@/stores/store';
+import { dataAtom } from '@/stores/structure';
 
+import { makeCommand } from './command';
 import { RoomView } from './components/RoomView';
 
 export const ChatRoomView = () => {
@@ -11,6 +14,15 @@ export const ChatRoomView = () => {
   const room = useRoomDataReadOnly(parseInt(id || ''));
   const [mySocket] = useAtom(chatSocketAtom);
   const [personalData] = useAtom(authAtom.personalData);
+  const [members] = dataAtom.useMembersInRoom(room?.id || -1);
+  const membersExists = !!members;
+  useEffect(() => {
+    if (!room || !mySocket || !personalData || membersExists) {
+      return;
+    }
+    const command = makeCommand(mySocket, room.id);
+    command.get_room_members(room.id);
+  }, [membersExists, mySocket, personalData, room]);
   if (!room || !mySocket || !personalData) {
     return null;
   }

--- a/frontend/src/features/Chat/ChatRoomView.tsx
+++ b/frontend/src/features/Chat/ChatRoomView.tsx
@@ -7,8 +7,5 @@ import { RoomView } from './components/RoomView';
 export const ChatRoomView = () => {
   const { id } = useParams();
   const room = useRoomDataReadOnly(parseInt(id || ''));
-  if (!room) {
-    return null;
-  }
   return <RoomView domain="chat" room={room} />;
 };

--- a/frontend/src/features/Chat/VisibleRoomList.tsx
+++ b/frontend/src/features/Chat/VisibleRoomList.tsx
@@ -47,21 +47,6 @@ export const VisibleRoomList = () => {
       return ms;
     },
   };
-
-  const action = {
-    /**
-     * 実態はステート更新関数.
-     * レンダリング後に副作用フックでコマンドが走る.
-     */
-    get_room_members: (roomId: number) => {
-      if (roomId > 0) {
-        const mems = store.roomMembers(roomId);
-        if (!mems) {
-          command.get_room_members(roomId);
-        }
-      }
-    },
-  };
   const predicate = {
     isJoiningTo: (roomId: number) =>
       !!joiningRooms.find((r) => r.chatRoom.id === roomId),
@@ -72,7 +57,6 @@ export const VisibleRoomList = () => {
   const onFocus = (roomId: number) => {
     if (predicate.isJoiningTo(roomId)) {
       navigate(`/chat/${roomId}`);
-      action.get_room_members(roomId);
     }
   };
   useEffect(() => {

--- a/frontend/src/features/Chat/components/InvitePrivateCard.tsx
+++ b/frontend/src/features/Chat/components/InvitePrivateCard.tsx
@@ -36,8 +36,7 @@ export const InvitePrivateCard = (props: {
   const [mySocket] = useAtom(chatSocketAtom);
   const [personalData] = useAtom(authAtom.personalData);
   const take = 5;
-  const [membersInRoom] = useAtom(dataAtom.membersInRoomAtom);
-  const members = membersInRoom[props.room.id];
+  const [members] = dataAtom.useMembersInRoom(props.room.id);
   const isDisabled = (user: displayUser) => !!members && !!members[user.id];
   const [error, setError] = useState('');
 

--- a/frontend/src/features/Chat/components/RoomView.tsx
+++ b/frontend/src/features/Chat/components/RoomView.tsx
@@ -368,8 +368,8 @@ const ActualView = ({
 };
 
 type Prop =
-  | { domain: 'chat'; room: TD.ChatRoom }
-  | { domain: 'dm'; room: TD.DmRoom };
+  | { domain: 'chat'; room?: TD.ChatRoom }
+  | { domain: 'dm'; room?: TD.DmRoom };
 export const RoomView = ({ room, domain }: Prop) => {
   const [mySocket] = useAtom(chatSocketAtom);
   const [personalData] = useAtom(authAtom.personalData);
@@ -388,7 +388,7 @@ export const RoomView = ({ room, domain }: Prop) => {
   const roomName =
     domain === 'chat'
       ? room.roomName
-      : room.roomMember.find((member) => member.userId !== personalData?.id)
+      : room.roomMember.find((member) => member.userId !== personalData.id)
           ?.user.displayName || '';
   return (
     <ActualView

--- a/frontend/src/features/Chat/components/RoomView.tsx
+++ b/frontend/src/features/Chat/components/RoomView.tsx
@@ -124,14 +124,6 @@ const MessagesList = (props: {
     get_room_messages(props.room.id, 50, oldestMessage?.id);
   }, [mySocket, scrollData, props.room.id]);
 
-  useEffect(() => {
-    if (!mySocket) {
-      return;
-    }
-    const { get_room_members } = makeCommand(mySocket, props.room.id);
-    get_room_members(props.room.id);
-  }, [mySocket, props.room.id]);
-
   const componentForMessage = (data: TD.ChatRoomMessage) => {
     if (data.messageType === 'PR_STATUS') {
       return ChatMatchingMessageCard;
@@ -229,15 +221,14 @@ export const RoomView = ({
   const navigate = useNavigate();
   const [members] = dataAtom.useMembersInRoom(room.id);
   const [messagesInRoom] = useAtom(dataAtom.messagesInRoomAtom);
-  const [membersInRoom] = useAtom(dataAtom.membersInRoomAtom);
   const computed = {
     you: useMemo(() => {
-      const us = membersInRoom[room.id];
+      const us = members;
       if (!us) {
         return null;
       }
       return us[personalData.id];
-    }, [membersInRoom, personalData, room.id]),
+    }, [members, personalData.id]),
   };
   const store = {
     roomMessages: (roomId: number) => {
@@ -249,7 +240,9 @@ export const RoomView = ({
     },
   };
   const command = makeCommand(mySocket, room.id);
-
+  if (!computed.you || !members) {
+    return null;
+  }
   const isOwner = room.ownerId === computed.you?.userId;
   const memberOperations: TD.MemberOperations | undefined =
     domain === 'chat'

--- a/frontend/src/features/DM/DmRoomView.tsx
+++ b/frontend/src/features/DM/DmRoomView.tsx
@@ -1,42 +1,14 @@
-import { useAtom } from 'jotai';
-import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { authAtom, chatSocketAtom } from '@/stores/auth';
 import { useDmRoomDataReadOnly } from '@/stores/store';
-import { dataAtom } from '@/stores/structure';
 
-import { makeCommand } from '../Chat/command';
 import { RoomView } from '../Chat/components/RoomView';
 
 export const DmRoomView = () => {
   const { id } = useParams();
   const room = useDmRoomDataReadOnly(parseInt(id || ''));
-  const [mySocket] = useAtom(chatSocketAtom);
-  const [personalData] = useAtom(authAtom.personalData);
-  const [members] = dataAtom.useMembersInRoom(room?.id || -1);
-  const membersExists = !!members;
-  useEffect(() => {
-    if (!room || !mySocket || !personalData || membersExists) {
-      return;
-    }
-    const command = makeCommand(mySocket, room.id);
-    command.get_room_members(room.id);
-  }, [membersExists, mySocket, personalData, room]);
-  if (!room || !mySocket || !personalData) {
+  if (!room) {
     return null;
   }
-
-  const roomName =
-    room.roomMember.find((member) => member.userId !== personalData.id)?.user
-      .displayName || '';
-  return (
-    <RoomView
-      domain="dm"
-      room={room}
-      roomName={roomName}
-      mySocket={mySocket}
-      personalData={personalData}
-    />
-  );
+  return <RoomView domain="dm" room={room} />;
 };

--- a/frontend/src/features/DM/DmRoomView.tsx
+++ b/frontend/src/features/DM/DmRoomView.tsx
@@ -7,8 +7,5 @@ import { RoomView } from '../Chat/components/RoomView';
 export const DmRoomView = () => {
   const { id } = useParams();
   const room = useDmRoomDataReadOnly(parseInt(id || ''));
-  if (!room) {
-    return null;
-  }
   return <RoomView domain="dm" room={room} />;
 };

--- a/frontend/src/features/DM/DmRoomView.tsx
+++ b/frontend/src/features/DM/DmRoomView.tsx
@@ -1,9 +1,12 @@
 import { useAtom } from 'jotai';
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { authAtom, chatSocketAtom } from '@/stores/auth';
 import { useDmRoomDataReadOnly } from '@/stores/store';
+import { dataAtom } from '@/stores/structure';
 
+import { makeCommand } from '../Chat/command';
 import { RoomView } from '../Chat/components/RoomView';
 
 export const DmRoomView = () => {
@@ -11,6 +14,15 @@ export const DmRoomView = () => {
   const room = useDmRoomDataReadOnly(parseInt(id || ''));
   const [mySocket] = useAtom(chatSocketAtom);
   const [personalData] = useAtom(authAtom.personalData);
+  const [members] = dataAtom.useMembersInRoom(room?.id || -1);
+  const membersExists = !!members;
+  useEffect(() => {
+    if (!room || !mySocket || !personalData || membersExists) {
+      return;
+    }
+    const command = makeCommand(mySocket, room.id);
+    command.get_room_members(room.id);
+  }, [membersExists, mySocket, personalData, room]);
   if (!room || !mySocket || !personalData) {
     return null;
   }

--- a/frontend/src/features/Socket/SocketHolder.tsx
+++ b/frontend/src/features/Socket/SocketHolder.tsx
@@ -186,10 +186,11 @@ export const SocketHolder = () => {
             console.log('is private');
             visibleRoomsUpdater.delOne(room);
           }
+          stateMutater.clearRoomMembers(room.id);
         } else {
           // 他人に関する通知
           console.log('for other');
-          stateMutater.removeMembersInRoom(room.id, user.id);
+          stateMutater.removeMemberFromRoom(room.id, user.id);
         }
       },
     ]);
@@ -211,10 +212,11 @@ export const SocketHolder = () => {
             console.log('is private');
             visibleRoomsUpdater.delOne(room);
           }
+          stateMutater.clearRoomMembers(room.id);
         } else {
           // 他人に関する通知
           console.log('for other');
-          stateMutater.removeMembersInRoom(room.id, user.id);
+          stateMutater.removeMemberFromRoom(room.id, user.id);
         }
       },
     ]);
@@ -438,7 +440,7 @@ export const SocketHolder = () => {
       });
     },
 
-    removeMembersInRoom: (roomId: number, userId: number) => {
+    removeMemberFromRoom: (roomId: number, userId: number) => {
       setMembersInRoom((prev) => {
         const next: { [roomId: number]: TD.UserRelationMap } = {};
         Utils.keys(prev).forEach((key) => {
@@ -449,6 +451,20 @@ export const SocketHolder = () => {
           return next;
         }
         delete members[userId];
+        return next;
+      });
+    },
+
+    clearRoomMembers: (roomId: number) => {
+      setMembersInRoom((prev) => {
+        const next: { [roomId: number]: TD.UserRelationMap } = {};
+        Utils.keys(prev).forEach((key) => {
+          next[key] = prev[key] ? { ...prev[key] } : {};
+        });
+        if (!next[roomId]) {
+          return next;
+        }
+        delete next[roomId];
         return next;
       });
     },

--- a/frontend/src/stores/structure.ts
+++ b/frontend/src/stores/structure.ts
@@ -71,16 +71,15 @@ export const dataAtom = {
   useMembersInRoom(id: number) {
     const [dict] = useAtom(derivedAtom.membersInRoomAtom);
     const [users] = useAtom(storeAtoms.users);
-    const members: TD.UserRelationMap = Utils.mapValues(
-      dict[id] || {},
-      (val, userId) => {
-        const user = users[userId] || val.user;
-        return {
-          ...val,
-          user,
-        };
-      }
-    );
+    const members: TD.UserRelationMap | null = dict[id]
+      ? Utils.mapValues(dict[id], (val, userId) => {
+          const user = users[userId] || val.user;
+          return {
+            ...val,
+            user,
+          };
+        })
+      : null;
     return [members] as const;
   },
 };


### PR DESCRIPTION
### 現象

joinしていないチャットルームのURLにアクセスすると、joinしていなくてもチャットルームのガワが表示される。

### 原因

`<RoomView>`のレンダリング条件に「自分が当該ルームのメンバーであること」が含まれていない。


### 対処

↑を含めるようにする。
・・・だけではダメだった。
というのは、「ルームメンバーがいない」と「ルームメンバーが未取得である」ことが区別されていなかったため。
→ 両者を区別するように設計を微修正した。

その上で、`<RoomView>`(の本体)を描画する条件に「ルームメンバーが取得済みであること」を追加した。