### PR TITLE
ユーザをkickした後に管理者操作のUIがユーザカードから消えない

### DIFF
--- a/frontend/src/components/ChatMatchingMessageCard.tsx
+++ b/frontend/src/components/ChatMatchingMessageCard.tsx
@@ -32,7 +32,7 @@ const CommandButton = ({ onClick, text }: ButtonProp) => (
 
 type PlayerProp = {
   user?: TD.User;
-  popoverContent: JSX.Element;
+  popoverContent?: () => JSX.Element;
   userScore?: number;
   side: 'left' | 'right';
   verdict: 'won' | 'lose' | 'none';
@@ -100,12 +100,8 @@ const PlayerCard = ({
     }
     const avatarButton = <UserAvatar user={user} onClick={openCard} />;
     return {
-      avatar: (
-        <PopoverUserCard button={avatarButton}>
-          {popoverContent}
-        </PopoverUserCard>
-      ),
-      name: <PopoverUserCard user={user}>{popoverContent}</PopoverUserCard>,
+      avatar: <PopoverUserCard button={avatarButton} inner={popoverContent} />,
+      name: <PopoverUserCard user={user} inner={popoverContent} />,
     };
   })();
   const color = {
@@ -178,11 +174,9 @@ export const ChatMatchingMessageCard = (props: ChatMessageProp) => {
   const opponentContent = (() => (
     <PlayerCard
       user={targetUser}
-      popoverContent={
-        targetUser && (
-          <AdminOperationBar {...props} member={props.members[targetUser.id]} />
-        )
-      }
+      popoverContent={() => (
+        <AdminOperationBar {...props} userId={targetUser?.id} />
+      )}
       userScore={userScore2}
       side="right"
       verdict={verdict2}
@@ -209,7 +203,7 @@ export const ChatMatchingMessageCard = (props: ChatMessageProp) => {
         <div className="flex flex-row items-center justify-center">
           <PlayerCard
             user={user}
-            popoverContent={<AdminOperationBar {...props} />}
+            popoverContent={() => <AdminOperationBar {...props} />}
             userScore={userScore1}
             side="left"
             verdict={verdict1}

--- a/frontend/src/components/ChatMessageCard.tsx
+++ b/frontend/src/components/ChatMessageCard.tsx
@@ -17,7 +17,6 @@ export type ChatMessageProp = {
   userId: number;
   member?: TD.ChatUserRelation;
   members: TD.UserRelationMap;
-  memberOperations?: TD.MemberOperations;
   id: string;
 };
 
@@ -35,14 +34,16 @@ export const ChatMessageCard = (props: ChatMessageProp) => {
   if (!user || isBlocked) {
     return null;
   }
+  const popoverContent = () => (
+    <AdminOperationBar room={props.room} userId={props.member?.userId} />
+  );
   const avatarButton = (
     <UserAvatar
       className="h-12 w-12 border-4 border-solid border-gray-600"
       user={user}
-      onClick={() => openCard(user, popoverContent || null)}
+      onClick={() => openCard(user, popoverContent)}
     />
   );
-  const popoverContent = <AdminOperationBar {...props} />;
   return (
     <div
       className="flex flex-row items-start px-2 py-1 hover:bg-gray-800"
@@ -50,14 +51,12 @@ export const ChatMessageCard = (props: ChatMessageProp) => {
       id={props.id}
     >
       <div className="shrink-0 grow-0">
-        <PopoverUserCard button={avatarButton}>
-          {popoverContent}
-        </PopoverUserCard>
+        <PopoverUserCard button={avatarButton} inner={popoverContent} />
       </div>
       <div className="flex shrink grow flex-col">
         <div className="flex max-w-[12em] shrink-0 grow-0 flex-row">
           <div className="m-[1px] shrink-0 grow-0 px-[2px] py-0">
-            <PopoverUserCard user={user}>{popoverContent}</PopoverUserCard>
+            <PopoverUserCard user={user} inner={popoverContent} />
           </div>
           <div className="shrink-0 grow-0 px-[4px]">
             {dayjs(props.message.createdAt).format('MM/DD HH:mm:ss')}

--- a/frontend/src/components/ChatSystemMessageCard.tsx
+++ b/frontend/src/components/ChatSystemMessageCard.tsx
@@ -170,18 +170,19 @@ export const ChatSystemMessageCard = (props: ChatMessageProp) => {
             <Content
               message={props.message}
               PrimaryChild={() => (
-                <PopoverUserCard user={user}>
-                  <AdminOperationBar {...props} />
-                </PopoverUserCard>
+                <PopoverUserCard
+                  user={user}
+                  inner={() => <AdminOperationBar {...props} />}
+                />
               )}
               SecondaryChild={() =>
                 targetUser && (
-                  <PopoverUserCard user={targetUser}>
-                    <AdminOperationBar
-                      {...props}
-                      member={props.members[targetUser.id]}
-                    />
-                  </PopoverUserCard>
+                  <PopoverUserCard
+                    user={targetUser}
+                    inner={() => (
+                      <AdminOperationBar {...props} userId={targetUser.id} />
+                    )}
+                  />
                 )
               }
             />

--- a/frontend/src/components/PopoverUserCard.tsx
+++ b/frontend/src/components/PopoverUserCard.tsx
@@ -7,20 +7,15 @@ type Prop = {
   className?: string;
   user?: User;
   button?: ReactNode;
-  children?: JSX.Element;
+  inner?: () => JSX.Element;
 };
 
-export const PopoverUserCard = ({
-  className,
-  user,
-  button,
-  children,
-}: Prop) => {
+export const PopoverUserCard = ({ className, user, button, inner }: Prop) => {
   const openCard = useUserCard();
   if (!user && !button) {
     return null;
   }
-  const inner = () => {
+  const content = () => {
     if (button) {
       return button;
     }
@@ -28,7 +23,7 @@ export const PopoverUserCard = ({
       return (
         <div
           className="max-w-[20em] overflow-hidden text-ellipsis px-1 align-middle font-bold hover:underline"
-          onClick={() => openCard(user, children || undefined)}
+          onClick={() => openCard(user, inner)}
         >
           {user.displayName}
         </div>
@@ -42,7 +37,7 @@ export const PopoverUserCard = ({
         className || ''
       }`}
     >
-      {inner()}
+      {content()}
     </div>
   );
 };

--- a/frontend/src/features/Chat/components/RoomView.tsx
+++ b/frontend/src/features/Chat/components/RoomView.tsx
@@ -37,7 +37,6 @@ const MessagesList = (props: {
   room: TD.ChatRoom;
   messages: TD.ChatRoomMessage[];
   members: TD.UserRelationMap;
-  memberOperations?: TD.MemberOperations;
 }) => {
   const listId = useId();
   const scrollData = useVerticalScrollAttr(listId);
@@ -156,7 +155,6 @@ const MessagesList = (props: {
             userId={data.userId}
             member={member}
             members={props.members}
-            memberOperations={props.memberOperations}
           />
         );
       })}
@@ -168,7 +166,6 @@ const MembersList = (props: {
   you: TD.ChatUserRelation | null;
   room: TD.ChatRoom;
   members: TD.UserRelationMap;
-  memberOperations?: TD.MemberOperations;
 }) => {
   const isPrivate = props.room.roomType === 'PRIVATE';
   const isOwner = props.room.ownerId === props.you?.userId;
@@ -251,15 +248,6 @@ export const RoomView = ({
   const command = makeCommand(mySocket, room.id);
 
   const isOwner = room.ownerId === computed.you?.userId;
-  const memberOperations: TD.MemberOperations | undefined =
-    domain === 'chat'
-      ? {
-          onNomminateClick: command.nomminate,
-          onBanClick: command.ban,
-          onKickClick: command.kick,
-          onMuteClick: command.mute,
-        }
-      : undefined;
   const TypeIcon = RoomTypeIcon[room.roomType];
   const barButtons = domain === 'chat' && (
     <>
@@ -349,7 +337,6 @@ export const RoomView = ({
               room={room}
               members={members}
               messages={store.roomMessages(room.id)}
-              memberOperations={memberOperations}
             />
           </div>
           <div className="shrink-0 grow-0 border-[2px] border-t-0 border-solid border-white p-2">
@@ -361,12 +348,7 @@ export const RoomView = ({
         </div>
         {domain === 'chat' && (
           <div className="ml-2 shrink-0 grow-0 basis-[16em] border-[2px] border-solid border-white bg-white">
-            <MembersList
-              you={computed.you}
-              room={room}
-              members={members}
-              memberOperations={memberOperations}
-            />
+            <MembersList you={computed.you} room={room} members={members} />
           </div>
         )}
       </div>

--- a/frontend/src/features/User/UserCardHolder.tsx
+++ b/frontend/src/features/User/UserCardHolder.tsx
@@ -8,14 +8,14 @@ import { UserCard } from './UserCard';
 export const UserCardHolder = () => {
   const [isOpen, setIsOpen] = useAtom(modalAtom.userCard.isOpen);
   const [user] = useAtom(modalAtom.userCard.user);
-  const [children] = useAtom(modalAtom.userCard.children);
+  const [inner] = useAtom(modalAtom.userCard.inner);
   // ここで if (!user) { return null; } としてしまうと,
   // モーダルの初回表示時に出現アニメーションが効かない
   return (
     <Modal closeModal={() => setIsOpen(false)} isOpen={isOpen}>
       {user && (
         <UserCard id={user.id} onClose={() => setIsOpen(false)}>
-          {children}
+          {inner && inner.f()}
         </UserCard>
       )}
     </Modal>

--- a/frontend/src/stores/control.ts
+++ b/frontend/src/stores/control.ts
@@ -8,7 +8,7 @@ export const modalAtom = {
   userCard: {
     isOpen: atom(false),
     user: atom<User | null>(null),
-    children: atom<JSX.Element | null>(null),
+    inner: atom<{ f: () => JSX.Element } | null>(null),
   },
 };
 
@@ -23,10 +23,10 @@ export function useUserCreatedForm() {
 export function useUserCard() {
   const [, setIsOpen] = useAtom(modalAtom.userCard.isOpen);
   const [, setUser] = useAtom(modalAtom.userCard.user);
-  const [, setChildren] = useAtom(modalAtom.userCard.children);
-  return function (user: User, children?: JSX.Element) {
+  const [, setInner] = useAtom(modalAtom.userCard.inner);
+  return function (user: User, inner?: () => JSX.Element) {
     setUser(user);
-    setChildren(children || null);
+    setInner(inner ? { f: inner } : null);
     setIsOpen(true);
   };
 }


### PR DESCRIPTION
> [ユーザカードの内部コンテンツ指定を, Elementではなく「Elementを返す関数」を与えるように変更](https://github.com/JUNNETWORKS/42-ft_transcendence/pull/391/commits/cc6f18bb25076587af3782d988107ca919f985ac)

Elementを与えてしまうと、内部コンテンツは与えたときの内容のまま変化しないが、
「Elementを返す関数」を与えれば、グローバルステートの変化により勝手に再描画される。